### PR TITLE
feat: Remove confusing properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,20 +48,17 @@ The `true` value of the `official` flag indicates that the extension is official
     {
       "module": "github.com/grafana/xk6-dashboard",
       "description": "Web-based metrics dashboard for k6",
-      "outputs": ["dashboard"],
-      "official": true
+      "outputs": ["dashboard"]
     },
     {
       "module": "github.com/grafana/xk6-sql",
       "description": "Load test SQL Servers",
-      "imports": ["k6/x/sql"],
-      "official": true
+      "imports": ["k6/x/sql"]
     },
     {
       "module": "github.com/grafana/xk6-distruptor",
       "description": "Inject faults to test",
-      "imports": ["k6/x/distruptor"],
-      "official": true
+      "imports": ["k6/x/distruptor"]
     },
     {
       "module": "github.com/szkiba/xk6-faker",

--- a/example.json
+++ b/example.json
@@ -3,20 +3,17 @@
     {
       "module": "github.com/grafana/xk6-dashboard",
       "description": "Web-based metrics dashboard for k6",
-      "outputs": ["dashboard"],
-      "official": true
+      "outputs": ["dashboard"]
     },
     {
       "module": "github.com/grafana/xk6-sql",
       "description": "Load test SQL Servers",
-      "imports": ["k6/x/sql"],
-      "official": true
+      "imports": ["k6/x/sql"]
     },
     {
       "module": "github.com/grafana/xk6-distruptor",
       "description": "Inject faults to test",
-      "imports": ["k6/x/distruptor"],
-      "official": true
+      "imports": ["k6/x/distruptor"]
     },
     {
       "module": "github.com/szkiba/xk6-faker",

--- a/registry.go
+++ b/registry.go
@@ -1,6 +1,6 @@
 // Package k6registry contains the data model of the k6 extensions registry.
 package k6registry
 
-//go:generate go run github.com/atombender/go-jsonschema@v0.16.0 -p k6registry --only-models -o registry_gen.go registry.schema.yaml
 //go:generate sh -c "go run github.com/mikefarah/yq/v4@v4.44.2 -o=json -P registry.schema.yaml > registry.schema.json"
+//go:generate go run github.com/atombender/go-jsonschema@v0.16.0 -p k6registry --only-models -o registry_gen.go registry.schema.yaml
 //go:generate go run github.com/szkiba/mdcode@v0.2.0 update

--- a/registry.schema.json
+++ b/registry.schema.json
@@ -60,16 +60,6 @@
             ]
           ]
         },
-        "official": {
-          "type": "boolean",
-          "default": "false",
-          "description": "Officially supported extension flag.\n\nA value of true indicates that the extension is officially supported by Grafana. Extensions owned by the `grafana` GitHub organization are not officially supported by Grafana by default.\n"
-        },
-        "cloud": {
-          "type": "boolean",
-          "default": "false",
-          "description": "Cloud-enabled extension flag.\n\nA value of true indicates that the extension is also available in the Grafana k6 cloud.\n"
-        },
         "description": {
           "type": "string",
           "description": "Brief description of the extension.\n"

--- a/registry.schema.yaml
+++ b/registry.schema.yaml
@@ -64,20 +64,6 @@ $defs:
         examples:
           - ["dashboard"]
           - ["plugin"]
-      official:
-        type: boolean
-        default: "false"
-        description: |
-          Officially supported extension flag.
-
-          A value of true indicates that the extension is officially supported by Grafana. Extensions owned by the `grafana` GitHub organization are not officially supported by Grafana by default.
-      cloud:
-        type: boolean
-        default: "false"
-        description: |
-          Cloud-enabled extension flag.
-
-          A value of true indicates that the extension is also available in the Grafana k6 cloud.
       description:
         type: string
         description: |

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -16,13 +16,6 @@ package k6registry
 // documentation site without approval. Therefore, these properties are registered
 // (eg `description`)
 type Extension struct {
-	// Cloud-enabled extension flag.
-	//
-	// A value of true indicates that the extension is also available in the Grafana
-	// k6 cloud.
-	//
-	Cloud bool `json:"cloud,omitempty" yaml:"cloud,omitempty" mapstructure:"cloud,omitempty"`
-
 	// Brief description of the extension.
 	//
 	Description string `json:"description" yaml:"description" mapstructure:"description"`
@@ -51,14 +44,6 @@ type Extension struct {
 	// that refers to the extension within the repository manager.
 	//
 	Module string `json:"module" yaml:"module" mapstructure:"module"`
-
-	// Officially supported extension flag.
-	//
-	// A value of true indicates that the extension is officially supported by
-	// Grafana. Extensions owned by the `grafana` GitHub organization are not
-	// officially supported by Grafana by default.
-	//
-	Official bool `json:"official,omitempty" yaml:"official,omitempty" mapstructure:"official,omitempty"`
 
 	// List of output names registered by the extension.
 	//


### PR DESCRIPTION
The cloud and official properties provide a kind of authorization to the extension, therefore it is confusing who can modify them and how. It is advisable to manage these in a source that relies on the registry but is independent of it.