### PR TITLE
Schema improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,5 +148,5 @@ Requires
 ## legacy - Convert legacy registry
 
 ```bash
- go run ./cmd/k6registry . --legacy | yq '.[]|= pick(["module","description","tier","product","imports","outputs","repo","categories"])|sort_by(.module)' > ./docs/legacy.yaml
+ go run ./cmd/k6registry . --legacy | yq '.[]|= pick(["module","description","tier","products","imports","outputs","repo","categories"])|sort_by(.module)' > ./docs/legacy.yaml
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,5 +148,5 @@ Requires
 ## legacy - Convert legacy registry
 
 ```bash
- go run ./cmd/k6registry . --legacy | yq '.[]|= pick(["module","description","tier","product","imports","outputs","repo"])|sort_by(.module)' > ./docs/legacy.yaml
+ go run ./cmd/k6registry . --legacy | yq '.[]|= pick(["module","description","tier","product","imports","outputs","repo","categories"])|sort_by(.module)' > ./docs/legacy.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check [k6 Extension Registry Concept](docs/registry.md) for information on desig
   imports:
     - k6/x/sql
   tier: official
-  product: ["cloud", "oss"]
+  products: ["cloud", "oss"]
   categories:
     - data
 
@@ -60,7 +60,7 @@ Registry generated from the source above.
     "outputs": [
       "dashboard"
     ],
-    "product": [
+    "products": [
       "oss"
     ],
     "repo": {
@@ -125,7 +125,7 @@ Registry generated from the source above.
       "k6/x/sql"
     ],
     "module": "github.com/grafana/xk6-sql",
-    "product": [
+    "products": [
       "cloud",
       "oss"
     ],
@@ -164,7 +164,7 @@ Registry generated from the source above.
       "k6/x/disruptor"
     ],
     "module": "github.com/grafana/xk6-disruptor",
-    "product": [
+    "products": [
       "oss"
     ],
     "repo": {
@@ -217,7 +217,7 @@ Registry generated from the source above.
       "k6/x/faker"
     ],
     "module": "github.com/szkiba/xk6-faker",
-    "product": [
+    "products": [
       "oss"
     ],
     "repo": {
@@ -250,7 +250,7 @@ Registry generated from the source above.
     ],
     "description": "A modern load testing tool, using Go and JavaScript",
     "module": "go.k6.io/k6",
-    "product": [
+    "products": [
       "cloud",
       "oss"
     ],

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Check [k6 Extension Registry Concept](docs/registry.md) for information on desig
   outputs:
     - dashboard
   tier: official
+  categories:
+    - reporting
+    - observability
 
 - module: github.com/grafana/xk6-sql
   description: Load test SQL Servers
@@ -21,17 +24,23 @@ Check [k6 Extension Registry Concept](docs/registry.md) for information on desig
     - k6/x/sql
   tier: official
   product: ["cloud", "oss"]
+  categories:
+    - data
 
 - module: github.com/grafana/xk6-disruptor
   description: Inject faults to test
   imports:
     - k6/x/disruptor
   tier: official
+  categories:
+    - kubernetes
 
 - module: github.com/szkiba/xk6-faker
   description: Generate random fake data
   imports:
     - k6/x/faker
+  categories:
+    - data
 ```
 
 <details>
@@ -42,6 +51,10 @@ Registry generated from the source above.
 ```json file=docs/example.json
 [
   {
+    "categories": [
+      "reporting",
+      "observability"
+    ],
     "description": "Web-based metrics dashboard for k6",
     "module": "github.com/grafana/xk6-dashboard",
     "outputs": [
@@ -57,7 +70,7 @@ Registry generated from the source above.
       "name": "xk6-dashboard",
       "owner": "grafana",
       "public": true,
-      "stars": 320,
+      "stars": 323,
       "topics": [
         "xk6",
         "xk6-official",
@@ -104,6 +117,9 @@ Registry generated from the source above.
     "tier": "official"
   },
   {
+    "categories": [
+      "data"
+    ],
     "description": "Load test SQL Servers",
     "imports": [
       "k6/x/sql"
@@ -120,7 +136,7 @@ Registry generated from the source above.
       "name": "xk6-sql",
       "owner": "grafana",
       "public": true,
-      "stars": 102,
+      "stars": 104,
       "topics": [
         "k6",
         "sql",
@@ -140,6 +156,9 @@ Registry generated from the source above.
     "tier": "official"
   },
   {
+    "categories": [
+      "kubernetes"
+    ],
     "description": "Inject faults to test",
     "imports": [
       "k6/x/disruptor"
@@ -190,6 +209,9 @@ Registry generated from the source above.
     "tier": "official"
   },
   {
+    "categories": [
+      "data"
+    ],
     "description": "Generate random fake data",
     "imports": [
       "k6/x/faker"
@@ -223,6 +245,9 @@ Registry generated from the source above.
     "tier": "community"
   },
   {
+    "categories": [
+      "misc"
+    ],
     "description": "A modern load testing tool, using Go and JavaScript",
     "module": "go.k6.io/k6",
     "product": [
@@ -236,7 +261,7 @@ Registry generated from the source above.
       "name": "k6",
       "owner": "grafana",
       "public": true,
-      "stars": 24184,
+      "stars": 24285,
       "topics": [
         "es6",
         "go",

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -56,6 +56,10 @@ func load(ctx context.Context, in io.Reader, loose bool, lint bool) (interface{}
 			registry[idx].Product = append(registry[idx].Product, k6registry.ProductOss)
 		}
 
+		if len(ext.Categories) == 0 {
+			registry[idx].Categories = append(registry[idx].Categories, k6registry.CategoryMisc)
+		}
+
 		if ext.Repo != nil {
 			continue
 		}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -41,7 +41,7 @@ func load(ctx context.Context, in io.Reader, loose bool, lint bool) (interface{}
 			Module:      k6Module,
 			Description: k6Description,
 			Tier:        k6registry.TierOfficial,
-			Product: []k6registry.Product{
+			Products: []k6registry.Product{
 				k6registry.ProductCloud,
 				k6registry.ProductOss,
 			},
@@ -52,8 +52,8 @@ func load(ctx context.Context, in io.Reader, loose bool, lint bool) (interface{}
 			registry[idx].Tier = k6registry.TierCommunity
 		}
 
-		if len(ext.Product) == 0 {
-			registry[idx].Product = append(registry[idx].Product, k6registry.ProductOss)
+		if len(ext.Products) == 0 {
+			registry[idx].Products = append(registry[idx].Products, k6registry.ProductOss)
 		}
 
 		if len(ext.Categories) == 0 {

--- a/docs/example.json
+++ b/docs/example.json
@@ -1,5 +1,9 @@
 [
   {
+    "categories": [
+      "reporting",
+      "observability"
+    ],
     "description": "Web-based metrics dashboard for k6",
     "module": "github.com/grafana/xk6-dashboard",
     "outputs": [
@@ -15,7 +19,7 @@
       "name": "xk6-dashboard",
       "owner": "grafana",
       "public": true,
-      "stars": 320,
+      "stars": 323,
       "topics": [
         "xk6",
         "xk6-official",
@@ -62,6 +66,9 @@
     "tier": "official"
   },
   {
+    "categories": [
+      "data"
+    ],
     "description": "Load test SQL Servers",
     "imports": [
       "k6/x/sql"
@@ -78,7 +85,7 @@
       "name": "xk6-sql",
       "owner": "grafana",
       "public": true,
-      "stars": 102,
+      "stars": 104,
       "topics": [
         "k6",
         "sql",
@@ -98,6 +105,9 @@
     "tier": "official"
   },
   {
+    "categories": [
+      "kubernetes"
+    ],
     "description": "Inject faults to test",
     "imports": [
       "k6/x/disruptor"
@@ -148,6 +158,9 @@
     "tier": "official"
   },
   {
+    "categories": [
+      "data"
+    ],
     "description": "Generate random fake data",
     "imports": [
       "k6/x/faker"
@@ -181,6 +194,9 @@
     "tier": "community"
   },
   {
+    "categories": [
+      "misc"
+    ],
     "description": "A modern load testing tool, using Go and JavaScript",
     "module": "go.k6.io/k6",
     "product": [
@@ -194,7 +210,7 @@
       "name": "k6",
       "owner": "grafana",
       "public": true,
-      "stars": 24184,
+      "stars": 24285,
       "topics": [
         "es6",
         "go",

--- a/docs/example.json
+++ b/docs/example.json
@@ -9,7 +9,7 @@
     "outputs": [
       "dashboard"
     ],
-    "product": [
+    "products": [
       "oss"
     ],
     "repo": {
@@ -74,7 +74,7 @@
       "k6/x/sql"
     ],
     "module": "github.com/grafana/xk6-sql",
-    "product": [
+    "products": [
       "cloud",
       "oss"
     ],
@@ -113,7 +113,7 @@
       "k6/x/disruptor"
     ],
     "module": "github.com/grafana/xk6-disruptor",
-    "product": [
+    "products": [
       "oss"
     ],
     "repo": {
@@ -166,7 +166,7 @@
       "k6/x/faker"
     ],
     "module": "github.com/szkiba/xk6-faker",
-    "product": [
+    "products": [
       "oss"
     ],
     "repo": {
@@ -199,7 +199,7 @@
     ],
     "description": "A modern load testing tool, using Go and JavaScript",
     "module": "go.k6.io/k6",
-    "product": [
+    "products": [
       "cloud",
       "oss"
     ],

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -3,6 +3,9 @@
   outputs:
     - dashboard
   tier: official
+  categories:
+    - reporting
+    - observability
 
 - module: github.com/grafana/xk6-sql
   description: Load test SQL Servers
@@ -10,14 +13,20 @@
     - k6/x/sql
   tier: official
   product: ["cloud", "oss"]
+  categories:
+    - data
 
 - module: github.com/grafana/xk6-disruptor
   description: Inject faults to test
   imports:
     - k6/x/disruptor
   tier: official
+  categories:
+    - kubernetes
 
 - module: github.com/szkiba/xk6-faker
   description: Generate random fake data
   imports:
     - k6/x/faker
+  categories:
+    - data

--- a/docs/example.yaml
+++ b/docs/example.yaml
@@ -12,7 +12,7 @@
   imports:
     - k6/x/sql
   tier: official
-  product: ["cloud", "oss"]
+  products: ["cloud", "oss"]
   categories:
     - data
 

--- a/docs/legacy.yaml
+++ b/docs/legacy.yaml
@@ -2,257 +2,403 @@
   description: Load-test Mongo no-SQL databases
   imports:
     - k6/x/mongo
+  categories:
+    - data
 - module: github.com/JorTurFer/xk6-input-prometheus
   description: Enables real-time input from prometheus
   imports:
     - k6/x/prometheusread
+  categories:
+    - data
 - module: github.com/Juandavi1/xk6-prompt
   description: Support for input arguments via UI.
   imports:
     - k6/x/prompt
+  categories:
+    - misc
 - module: github.com/LeonAdato/xk6-output-statsd
   description: Enables real-time output of test metrics to a StatsD service
   outputs:
     - output-statsd
+  categories:
+    - observability
 - module: github.com/Maksimall89/xk6-output-clickhouse
   description: Export results to ClickHouse
   outputs:
     - clickhouse
+  categories:
+    - reporting
+    - observability
 - module: github.com/SYM01/xk6-proxy
   description: Add a dynamic proxy support to k6. Allow changing the HTTP proxy settings in the script.
   imports:
     - k6/x/proxy
+  categories:
+    - protocol
 - module: github.com/acuenca-facephi/xk6-read
   description: Read files and directories
   imports:
     - k6/x/read
+  categories:
+    - misc
 - module: github.com/akiomik/xk6-nostr
   description: Interact with Nostr relays
   imports:
     - k6/x/nostr
+  categories:
+    - messaging
+    - protocol
 - module: github.com/anycable/xk6-cable
   description: Test Action Cable and AnyCable functionality
   imports:
     - k6/x/cable
+  categories:
+    - messaging
 - module: github.com/avitalique/xk6-file
   description: Write files
   imports:
     - k6/x/file
+  categories:
+    - misc
 - module: github.com/deejiw/xk6-gcp
   description: A k6 extension for Google Cloud Platform services.
   imports:
     - k6/x/gcp
+  categories:
+    - misc
 - module: github.com/deejiw/xk6-interpret
   description: Interpret Go code
   imports:
     - k6/x/interpret
+  categories:
+    - misc
 - module: github.com/distribworks/xk6-ethereum
   description: K6 extension for ethereum protocols
   imports:
     - k6/x/ethereum
+  categories:
+    - protocol
 - module: github.com/domsolutions/xk6-fasthttp
   description: Enable RPS increase & file streaming on HTTP/1.1 requests
   imports:
     - k6/x/fasthttp
+  categories:
+    - protocol
 - module: github.com/elastic/xk6-output-elasticsearch
   description: Export results to Elasticsearch 8.x
   outputs:
     - output-elasticsearch
+  categories:
+    - data
 - module: github.com/frankhefeng/xk6-oauth-pkce
   description: Generate OAuth PKCE code verifier and code challenge
   imports:
     - k6/x/oauth-pkce
+  categories:
+    - authentication
 - module: github.com/gjergjsheldija/xk6-mllp
   description: Simple MLLP sender for k6
   imports:
     - k6/x/mllp
+  categories:
+    - messaging
 - module: github.com/golioth/xk6-coap
   description: Interact with Constrained Application Protocol endpoints.
   imports:
     - k6/x/coap
+  categories:
+    - messaging
+    - protocol
 - module: github.com/gpiechnik2/xk6-httpagg
   description: Aggregate HTTP requests into an HTML report
   imports:
     - k6/x/httpagg
+  categories:
+    - reporting
 - module: github.com/gpiechnik2/xk6-smtp
   description: Use SMTP protocol to send emails
   imports:
     - k6/x/smtp
+  categories:
+    - protocol
 - module: github.com/grafana/xk6-client-prometheus-remote
   description: Test Prometheus Remote Write performance
   tier: official
   imports:
     - k6/x/remotewrite
+  categories:
+    - observability
 - module: github.com/grafana/xk6-client-tracing
   description: Client for load testing distributed tracing backends
   tier: official
   imports:
     - k6/x/tracing
+  categories:
+    - observability
 - module: github.com/grafana/xk6-dashboard
   description: Create a web-based metrics dashboard
   tier: official
   outputs:
     - dashboard
+  categories:
+    - reporting
+    - observability
 - module: github.com/grafana/xk6-disruptor
   description: "Inject faults to test \U0001F4A3"
   tier: official
   imports:
     - k6/x/disruptor
+  categories:
+    - kubernetes
 - module: github.com/grafana/xk6-exec
   description: Run external commands
   tier: official
   imports:
     - k6/x/exec
+  categories:
+    - misc
 - module: github.com/grafana/xk6-kubernetes
   description: Interact with Kubernetes clusters
   tier: official
   imports:
     - k6/x/kubernetes
+  categories:
+    - kubernetes
+- module: github.com/grafana/xk6-loki
+  description: Client for load testing Loki
+  tier: official
+  imports:
+    - k6/x/loki
+  categories:
+    - observability
+    - messaging
 - module: github.com/grafana/xk6-notification
   description: Create notifications
   tier: official
   imports:
     - k6/x/notification
+  categories:
+    - reporting
 - module: github.com/grafana/xk6-output-influxdb
   description: Export results to InfluxDB v2
   tier: official
   outputs:
     - xk6-influxdb
+  categories:
+    - data
 - module: github.com/grafana/xk6-output-kafka
   description: Export k6 results in real-time to Kafka
   tier: official
   outputs:
     - xk6-kafka
+  categories:
+    - reporting
+    - messaging
 - module: github.com/grafana/xk6-output-timescaledb
   description: Export k6 results to TimescaleDB
   tier: official
   outputs:
     - timescaledb
+  categories:
+    - reporting
+    - data
 - module: github.com/grafana/xk6-sql
   description: Load-test SQL Servers (PostgreSQL, MySQL and SQLite3 for now)
   tier: official
   imports:
     - k6/x/sql
+  categories:
+    - data
 - module: github.com/grafana/xk6-ssh
   description: SSH
   tier: official
   imports:
     - k6/x/ssh
+  categories:
+    - misc
 - module: github.com/grafana/xk6-ts
   description: Add TypeScript support for k6
   imports:
     - k6/x/ts
+  categories:
+    - misc
 - module: github.com/kelseyaubrecht/xk6-webtransport
   description: Add support for webtransport protocol
   imports:
     - k6/x/webtransport
+  categories:
+    - messaging
+    - protocol
 - module: github.com/kubeshop/xk6-tracetest
   description: Support for Tracetest test execution and tracing client
   outputs:
     - tracetest
+  categories:
+    - observability
 - module: github.com/leonyork/xk6-output-timestream
   description: Export results to AWS Timestream
   outputs:
     - timestream
+  categories:
+    - reporting
+    - data
 - module: github.com/maksimall89/xk6-telegram
   description: Interact with Telegram Bots
   imports:
     - k6/x/telegram
+  categories:
+    - reporting
+    - messaging
 - module: github.com/martymarron/xk6-output-prometheus-pushgateway
   description: Export results to Prometheus pushgateway
   imports:
     - k6/x/output-prometheus-pushgateway
   outputs:
     - output-prometheus-pushgateway
+  categories:
+    - reporting
+    - observability
+    - data
 - module: github.com/mostafa/xk6-kafka
   description: Load-test Apache Kafka. Includes support for Avro messages
   imports:
     - k6/x/kafka
+  categories:
+    - messaging
 - module: github.com/nicholasvuono/xk6-playwright
   description: Browser automation and end-to-end web testing using Playwright
   imports:
     - k6/x/playwright
+  categories:
+    - browser
 - module: github.com/oleiade/xk6-kv
   description: Share key-value data between VUs
   imports:
     - k6/x/kv
+  categories:
+    - data
 - module: github.com/phymbert/xk6-sse
   description: A k6 extension for Server-Sent Events (SSE)
   imports:
     - k6/x/sse
+  categories:
+    - protocol
 - module: github.com/pmalhaire/xk6-mqtt
   description: MQTT extension
   imports:
     - k6/x/mqtt
+  categories:
+    - messaging
 - module: github.com/skibum55/xk6-git
   description: Clone Git repositories from tests
   imports:
     - k6/x/git
+  categories:
+    - data
+    - protocol
 - module: github.com/szkiba/xk6-ansible-vault
   description: Encrypt and decrypt Ansible Vault
   imports:
     - k6/x/ansible-vault
+  categories:
+    - data
 - module: github.com/szkiba/xk6-cache
   description: Enable vendoring remote HTTP modules to a single source-control-friendly file
   outputs:
     - cache
+  categories:
+    - misc
 - module: github.com/szkiba/xk6-chai
   description: Embed k6chaijs into the k6 binary
   imports:
     - k6/x/chai
+  categories:
+    - misc
 - module: github.com/szkiba/xk6-csv
   description: Parse CSV values
   imports:
     - k6/x/csv
+  categories:
+    - data
 - module: github.com/szkiba/xk6-dotenv
   description: Load env vars from a .env file
   imports:
     - k6/x/dotenv
+  categories:
+    - misc
 - module: github.com/szkiba/xk6-faker
   description: Generate random fake data
   imports:
     - k6/x/faker
+  categories:
+    - data
 - module: github.com/szkiba/xk6-g0
   description: Write k6 tests in golang
   imports:
     - k6/x/g0
+  categories:
+    - misc
 - module: github.com/szkiba/xk6-mock
   description: Mock HTTP(S) servers
   imports:
     - k6/x/mock
+  categories:
+    - misc
 - module: github.com/szkiba/xk6-output-plugin
   description: Write k6 output extension as a dynamically loadable plugin using your favorite programming language
   outputs:
     - plugin
+  categories:
+    - reporting
+    - data
 - module: github.com/szkiba/xk6-prometheus
   description: Prometheus HTTP exporter for k6
   outputs:
     - prometheus
+  categories:
+    - reporting
+    - observability
 - module: github.com/szkiba/xk6-toml
   description: Encode and decode TOML values
   imports:
     - k6/x/toml
+  categories:
+    - data
 - module: github.com/szkiba/xk6-top
   description: Updating the current k6 metrics summaries on the terminal during the test run
   outputs:
     - top
+  categories:
+    - reporting
+    - observability
 - module: github.com/szkiba/xk6-yaml
   description: Encode and decode YAML values
   imports:
     - k6/x/yaml
+  categories:
+    - data
 - module: github.com/thmshmm/xk6-opentelemetry
   description: Generate OpenTelemetry signals from within your test scripts
   imports:
     - k6/x/opentelemetry
+  categories:
+    - observability
 - module: github.com/thotasrinath/xk6-couchbase
   description: Load-test Couchbase no-SQL databases
   imports:
     - k6/x/couchbase
+  categories:
+    - data
 - module: github.com/tmieulet/xk6-cognito
   description: Get a cognito access token using USER_SRP_AUTH flow
   imports:
     - k6/x/cognito
+  categories:
+    - authentication
 - module: github.com/walterwanderley/xk6-stomp
   description: Client for STOMP protocol
   imports:
     - k6/x/stomp
+  categories:
+    - messaging
+    - protocol

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -74,6 +74,9 @@ If the property is missing or empty in the source of the registry, it means that
   outputs:
     - dashboard
   tier: official
+  categories:
+    - reporting
+    - observability
 
 - module: github.com/grafana/xk6-sql
   description: Load test SQL Servers
@@ -81,17 +84,23 @@ If the property is missing or empty in the source of the registry, it means that
     - k6/x/sql
   tier: official
   product: ["cloud", "oss"]
+  categories:
+    - data
 
 - module: github.com/grafana/xk6-disruptor
   description: Inject faults to test
   imports:
     - k6/x/disruptor
   tier: official
+  categories:
+    - kubernetes
 
 - module: github.com/szkiba/xk6-faker
   description: Generate random fake data
   imports:
     - k6/x/faker
+  categories:
+    - data
 ```
 
 ### Repository Metadata

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -103,6 +103,24 @@ If the property is missing or empty in the source of the registry, it means that
     - data
 ```
 
+### Categories
+
+The `categories` property contains the categories to which the extension belongs.
+
+If the property is missing or empty in the registry source, the default value is "misc".
+
+Possible values:
+
+  - **authentication**
+  - **browser**
+  - **data**
+  - **kubernetes**
+  - **messaging**
+  - **misc**
+  - **observability**
+  - **protocol**
+  - **reporting**
+
 ### Repository Metadata
 
 Repository metadata provided by the extension's git repository manager. Repository metadata are not registered, they are queried at processing time using the repository manager API.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -53,9 +53,9 @@ Extensions owned by the `grafana` GitHub organization are not officially support
 
 If it is missing from the registry source, it will be set with the default `community` value during generation.
 
-### Product
+### Products
 
-The `product` property contains the names of the k6 products in which the extension is available.
+The `products` property contains the names of the k6 products in which the extension is available.
 
 Some extensions are not available in all k6 products. This may be for a technological or business reason, or the functionality of the extension may not make sense in the given product.
 
@@ -83,7 +83,7 @@ If the property is missing or empty in the source of the registry, it means that
   imports:
     - k6/x/sql
   tier: official
-  product: ["cloud", "oss"]
+  products: ["cloud", "oss"]
   categories:
     - data
 

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -67,7 +67,7 @@
           "default": "community",
           "description": "Maintainer of the extension.\n\nPossible values:\n\n  - official: Extensions owned, maintained, and designated by Grafana as \"official\"\n  - partner: Extensions written, maintained, validated, and published by third-party companies against their own projects.\n  - community: Extensions are listed on the Registry by individual maintainers, groups of maintainers, or other members of the k6 community.\n\nExtensions owned by the `grafana` GitHub organization are not officially supported by Grafana by default.\nThere are several k6 extensions owned by the `grafana` GitHub organization, which were created for experimental or example purposes only.\nThe `official` tier value is needed so that officially supported extensions can be distinguished from them.\n\nIf it is missing from the registry source, it will be set with the default \"community\" value during generation.\n"
         },
-        "product": {
+        "products": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/product"

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -25,7 +25,8 @@
         "imports": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^k6/x/"
           },
           "description": "List of JavaScript import paths registered by the extension.\n\nCurrently, paths must start with the prefix `k6/x/`.\n\nThe extensions used by k6 scripts are automatically detected based on the values specified here, therefore it is important that the values used here are consistent with the values registered by the extension at runtime.\n",
           "examples": [

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -65,7 +65,7 @@
         "tier": {
           "$ref": "#/$defs/tier",
           "default": "community",
-          "description": "Maintainer of the extension.\n\nPossible values:\n\n  - official: Extensions owned, maintained, and designated by Grafana as \"official\"\n  - partner: Extensions written, maintained, validated, and published by third-party companies against their own projects.\n  - community: Extensions are listed on the Registry by individual maintainers, groups of maintainers, or other members of the k6 community.\n\nExtensions owned by the `grafana` GitHub organization are not officially supported by Grafana by default.\nThere are several k6 extensions owned by the `grafana` GitHub organization, which were created for experimental or example purposes only.\nThe `official` tier value is needed so that officially supported extensions can be distinguished from them.\n"
+          "description": "Maintainer of the extension.\n\nPossible values:\n\n  - official: Extensions owned, maintained, and designated by Grafana as \"official\"\n  - partner: Extensions written, maintained, validated, and published by third-party companies against their own projects.\n  - community: Extensions are listed on the Registry by individual maintainers, groups of maintainers, or other members of the k6 community.\n\nExtensions owned by the `grafana` GitHub organization are not officially supported by Grafana by default.\nThere are several k6 extensions owned by the `grafana` GitHub organization, which were created for experimental or example purposes only.\nThe `official` tier value is needed so that officially supported extensions can be distinguished from them.\n\nIf it is missing from the registry source, it will be set with the default \"community\" value during generation.\n"
         },
         "product": {
           "type": "array",
@@ -73,6 +73,13 @@
             "$ref": "#/$defs/product"
           },
           "description": "Products in which the extension can be used.\n\nSome extensions are not available in all k6 products.\nThis may be for a technological or business reason, or the functionality of the extension may not make sense in the given product.\n\nPossible values:\n\n  - oss: Extensions are available in k6 OSS\n  - cloud: Extensions are available in Grafana Cloud k6\n\nIf the property is missing or empty in the source of the registry, it means that the extension is only available in the k6 OSS product.\nIn this case, the registry will be filled in accordingly during generation.\n"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/category"
+          },
+          "description": "The categories to which the extension belongs.\n\nIf the property is missing or empty in the registry source, the default value is \"misc\".\n\nPossible values:\n\n  - authentication\n  - browser\n  - data\n  - kubernetes\n  - messaging\n  - misc\n  - observability\n  - protocol\n  - reporting\n"
         }
       },
       "required": [
@@ -155,7 +162,7 @@
         "partner",
         "community"
       ],
-      "description": "Maintainer of the extension.\n\nExtensions can be classified according to who maintains the extension.\nThis usually also specifies who the user can get support from.\n\nPossible values:\n\n  - official: Extensions owned, maintained, and designated by Grafana as \"official\"\n  - partner: Extensions written, maintained, validated, and published by third-party companies against their own projects.\n  - community: Extensions are listed on the Registry by individual maintainers, groups of maintainers, or other members of the k6 community.\n\nExtensions owned by the `grafana` GitHub organization are not officially supported by Grafana by default.\nThere are several k6 extensions owned by the `grafana` GitHub organization, which were created for experimental or example purposes only.\nThe `official` tier value is needed so that officially supported extensions can be distinguished from them.\n"
+      "description": "Maintainer of the extension.\n\nExtensions can be classified according to who maintains the extension.\nThis usually also specifies who the user can get support from.\n\nPossible values:\n\n  - official: Extensions owned, maintained, and designated by Grafana as \"official\"\n  - partner: Extensions written, maintained, validated, and published by third-party companies against their own projects.\n  - community: Extensions are listed on the Registry by individual maintainers, groups of maintainers, or other members of the k6 community.\n\nExtensions owned by the `grafana` GitHub organization are not officially supported by Grafana by default.\nThere are several k6 extensions owned by the `grafana` GitHub organization, which were created for experimental or example purposes only.\nThe `official` tier value is needed so that officially supported extensions can be distinguished from them.\n\nIf it is missing from the registry source, it will be set with the default \"community\" value during generation.\n"
     },
     "product": {
       "type": "string",
@@ -164,6 +171,21 @@
         "cloud"
       ],
       "description": "Products in which the extension can be used.\n\nSome extensions are not available in all k6 products.\nThis may be for a technological or business reason, or the functionality of the extension may not make sense in the given product.\n\nPossible values:\n\n  - oss: Extensions are available in k6 OSS\n  - cloud: Extensions are available in Grafana Cloud k6\n\nIf the property is missing or empty in the source of the registry, it means that the extension is only available in the k6 OSS product.\nIn this case, the registry will be filled in accordingly during generation.\n"
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "authentication",
+        "browser",
+        "data",
+        "kubernetes",
+        "messaging",
+        "misc",
+        "observability",
+        "protocol",
+        "reporting"
+      ],
+      "description": "The categories to which the extension belongs.\n\nIf the property is missing or empty in the registry source, the default value is \"misc\".\n\nPossible values:\n\n  - authentication\n  - browser\n  - data\n  - kubernetes\n  - messaging\n  - misc\n  - observability\n  - protocol\n  - reporting\n"
     }
   }
 }

--- a/docs/registry.schema.yaml
+++ b/docs/registry.schema.yaml
@@ -39,6 +39,7 @@ $defs:
         type: array
         items:
           type: string
+          pattern: "^k6/x/"
         description: |
           List of JavaScript import paths registered by the extension.
 

--- a/docs/registry.schema.yaml
+++ b/docs/registry.schema.yaml
@@ -106,6 +106,27 @@ $defs:
           If the property is missing or empty in the source of the registry, it means that the extension is only available in the k6 OSS product.
           In this case, the registry will be filled in accordingly during generation.
 
+      categories:
+        type: array
+        items:
+          $ref: "#/$defs/category"
+        description: |
+          The categories to which the extension belongs.
+
+          If the property is missing or empty in the registry source, the default value is "misc".
+
+          Possible values:
+
+            - authentication
+            - browser
+            - data
+            - kubernetes
+            - messaging
+            - misc
+            - observability
+            - protocol
+            - reporting
+
     required:
       - module
       - description
@@ -230,3 +251,31 @@ $defs:
 
       If the property is missing or empty in the source of the registry, it means that the extension is only available in the k6 OSS product.
       In this case, the registry will be filled in accordingly during generation.
+  category:
+    type: string
+    enum:
+      - authentication
+      - browser
+      - data
+      - kubernetes
+      - messaging
+      - misc
+      - observability
+      - protocol
+      - reporting
+    description: |
+      The categories to which the extension belongs.
+
+      If the property is missing or empty in the registry source, the default value is "misc".
+
+      Possible values:
+
+        - authentication
+        - browser
+        - data
+        - kubernetes
+        - messaging
+        - misc
+        - observability
+        - protocol
+        - reporting

--- a/docs/registry.schema.yaml
+++ b/docs/registry.schema.yaml
@@ -88,7 +88,7 @@ $defs:
 
           If it is missing from the registry source, it will be set with the default "community" value during generation.
 
-      product:
+      products:
         type: array
         items:
           $ref: "#/$defs/product"

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -2,6 +2,18 @@
 
 package k6registry
 
+type Category string
+
+const CategoryAuthentication Category = "authentication"
+const CategoryBrowser Category = "browser"
+const CategoryData Category = "data"
+const CategoryKubernetes Category = "kubernetes"
+const CategoryMessaging Category = "messaging"
+const CategoryMisc Category = "misc"
+const CategoryObservability Category = "observability"
+const CategoryProtocol Category = "protocol"
+const CategoryReporting Category = "reporting"
+
 // Properties of the registered k6 extension.
 //
 // Only those properties of the extensions are registered, which either cannot be
@@ -16,6 +28,26 @@ package k6registry
 // documentation site without approval. Therefore, these properties are registered
 // (eg `description`)
 type Extension struct {
+	// The categories to which the extension belongs.
+	//
+	// If the property is missing or empty in the registry source, the default value
+	// is "misc".
+	//
+	// Possible values:
+	//
+	//   - authentication
+	//   - browser
+	//   - data
+	//   - kubernetes
+	//   - messaging
+	//   - misc
+	//   - observability
+	//   - protocol
+	//   - reporting
+	//
+	//
+	Categories []Category `json:"categories,omitempty" yaml:"categories,omitempty" mapstructure:"categories,omitempty"`
+
 	// Brief description of the extension.
 	//
 	Description string `json:"description" yaml:"description" mapstructure:"description"`
@@ -97,6 +129,9 @@ type Extension struct {
 	// which were created for experimental or example purposes only.
 	// The `official` tier value is needed so that officially supported extensions can
 	// be distinguished from them.
+	//
+	// If it is missing from the registry source, it will be set with the default
+	// "community" value during generation.
 	//
 	//
 	Tier Tier `json:"tier,omitempty" yaml:"tier,omitempty" mapstructure:"tier,omitempty"`

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -102,7 +102,7 @@ type Extension struct {
 	// In this case, the registry will be filled in accordingly during generation.
 	//
 	//
-	Product []Product `json:"product,omitempty" yaml:"product,omitempty" mapstructure:"product,omitempty"`
+	Products []Product `json:"products,omitempty" yaml:"products,omitempty" mapstructure:"products,omitempty"`
 
 	// Repository metadata.
 	//

--- a/releases/v0.1.11.md
+++ b/releases/v0.1.11.md
@@ -3,3 +3,4 @@ k6registry `v0.1.11` is here 🎉!
 This is an internal maintenance release.
 
 - Categories support: added `categories` array property to extensions. Categories can be predefined string values.
+- Rename `product` property to `products`: the `product` property is an array, so the name should be plural (`products`).

--- a/releases/v0.1.11.md
+++ b/releases/v0.1.11.md
@@ -4,3 +4,4 @@ This is an internal maintenance release.
 
 - Categories support: added `categories` array property to extensions. Categories can be predefined string values.
 - Rename `product` property to `products`: the `product` property is an array, so the name should be plural (`products`).
+- Force the `k6/x/` path prefix in the import path.

--- a/releases/v0.1.11.md
+++ b/releases/v0.1.11.md
@@ -1,0 +1,5 @@
+k6registry `v0.1.11` is here 🎉!
+
+This is an internal maintenance release.
+
+- Categories support: added `categories` array property to extensions. Categories can be predefined string values.


### PR DESCRIPTION
- Categories support: added `categories` array property to extensions. Categories can be predefined string values.
- Rename `product` property to `products`: the `product` property is an array, so the name should be plural (`products`).
- Force the `k6/x/` path prefix in the import path.
