### PR TITLE
added repo metadata for linter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Registry generated from the source above.
       "owner": "grafana",
       "public": true,
       "stars": 325,
+      "timestamp": 1719907965,
       "topics": [
         "xk6",
         "xk6-official",
@@ -144,6 +145,7 @@ Registry generated from the source above.
       "owner": "grafana",
       "public": true,
       "stars": 104,
+      "timestamp": 1721400602,
       "topics": [
         "k6",
         "sql",
@@ -182,6 +184,7 @@ Registry generated from the source above.
       "owner": "grafana",
       "public": true,
       "stars": 88,
+      "timestamp": 1724358828,
       "topics": [
         "chaos-engineering",
         "fault-injection",
@@ -235,6 +238,7 @@ Registry generated from the source above.
       "owner": "szkiba",
       "public": true,
       "stars": 49,
+      "timestamp": 1719935566,
       "topics": [
         "xk6",
         "xk6-javascript-k6-x-faker"
@@ -270,6 +274,7 @@ Registry generated from the source above.
       "name": "xk6-banner",
       "owner": "szkiba",
       "public": true,
+      "timestamp": 1724312566,
       "topics": [
         "xk6"
       ],
@@ -297,7 +302,6 @@ Registry generated from the source above.
       "name": "k6",
       "owner": "grafana",
       "public": true,
-      "stars": 24302,
       "topics": [
         "es6",
         "go",

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Registry generated from the source above.
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/xk6-dashboard.git",
       "description": "A k6 extension that makes k6 metrics available on a web-based dashboard.",
       "homepage": "https://github.com/grafana/xk6-dashboard",
       "license": "AGPL-3.0",
@@ -138,6 +139,7 @@ Registry generated from the source above.
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/xk6-sql.git",
       "description": "k6 extension to load test RDBMSs (PostgreSQL, MySQL, MS SQL and SQLite3)",
       "homepage": "https://github.com/grafana/xk6-sql",
       "license": "Apache-2.0",
@@ -177,6 +179,7 @@ Registry generated from the source above.
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/xk6-disruptor.git",
       "description": "Extension for injecting faults into k6 tests",
       "homepage": "https://k6.io/docs/javascript-api/xk6-disruptor/",
       "license": "AGPL-3.0",
@@ -231,6 +234,7 @@ Registry generated from the source above.
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/szkiba/xk6-faker.git",
       "description": "Random fake data generator for k6.",
       "homepage": "http://ivan.szkiba.hu/xk6-faker/",
       "license": "AGPL-3.0",
@@ -268,6 +272,7 @@ Registry generated from the source above.
       "oss"
     ],
     "repo": {
+      "clone_url": "https://gitlab.com/szkiba/xk6-banner.git",
       "description": "Print ASCII art banner from k6 test.",
       "homepage": "https://gitlab.com/szkiba/xk6-banner",
       "license": "MIT",
@@ -296,6 +301,7 @@ Registry generated from the source above.
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/k6.git",
       "description": "A modern load testing tool, using Go and JavaScript - https://k6.io",
       "homepage": "https://github.com/grafana/k6",
       "license": "AGPL-3.0",

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -172,6 +172,8 @@ func loadGitHub(ctx context.Context, module string) (*k6registry.Repository, err
 		repo.Timestamp = float64(ts.Unix())
 	}
 
+	repo.CloneUrl = rep.GetCloneURL()
+
 	tags, _, err := client.Repositories.ListTags(ctx, owner, name, &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return nil, err
@@ -216,6 +218,8 @@ func loadGitLab(ctx context.Context, module string) (*k6registry.Repository, err
 	repo.Homepage = proj.WebURL
 	repo.Topics = proj.Topics
 	repo.Public = len(proj.Visibility) == 0 || proj.Visibility == gitlab.PublicVisibility
+
+	repo.CloneUrl = proj.HTTPURLToRepo
 
 	if proj.LastActivityAt != nil {
 		repo.Timestamp = float64(proj.LastActivityAt.Unix())

--- a/docs/example.json
+++ b/docs/example.json
@@ -20,6 +20,7 @@
       "owner": "grafana",
       "public": true,
       "stars": 325,
+      "timestamp": 1719907965,
       "topics": [
         "xk6",
         "xk6-official",
@@ -86,6 +87,7 @@
       "owner": "grafana",
       "public": true,
       "stars": 104,
+      "timestamp": 1721400602,
       "topics": [
         "k6",
         "sql",
@@ -124,6 +126,7 @@
       "owner": "grafana",
       "public": true,
       "stars": 88,
+      "timestamp": 1724358828,
       "topics": [
         "chaos-engineering",
         "fault-injection",
@@ -177,6 +180,7 @@
       "owner": "szkiba",
       "public": true,
       "stars": 49,
+      "timestamp": 1719935566,
       "topics": [
         "xk6",
         "xk6-javascript-k6-x-faker"
@@ -212,6 +216,7 @@
       "name": "xk6-banner",
       "owner": "szkiba",
       "public": true,
+      "timestamp": 1724312566,
       "topics": [
         "xk6"
       ],
@@ -239,7 +244,6 @@
       "name": "k6",
       "owner": "grafana",
       "public": true,
-      "stars": 24302,
       "topics": [
         "es6",
         "go",

--- a/docs/example.json
+++ b/docs/example.json
@@ -13,6 +13,7 @@
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/xk6-dashboard.git",
       "description": "A k6 extension that makes k6 metrics available on a web-based dashboard.",
       "homepage": "https://github.com/grafana/xk6-dashboard",
       "license": "AGPL-3.0",
@@ -80,6 +81,7 @@
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/xk6-sql.git",
       "description": "k6 extension to load test RDBMSs (PostgreSQL, MySQL, MS SQL and SQLite3)",
       "homepage": "https://github.com/grafana/xk6-sql",
       "license": "Apache-2.0",
@@ -119,6 +121,7 @@
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/xk6-disruptor.git",
       "description": "Extension for injecting faults into k6 tests",
       "homepage": "https://k6.io/docs/javascript-api/xk6-disruptor/",
       "license": "AGPL-3.0",
@@ -173,6 +176,7 @@
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/szkiba/xk6-faker.git",
       "description": "Random fake data generator for k6.",
       "homepage": "http://ivan.szkiba.hu/xk6-faker/",
       "license": "AGPL-3.0",
@@ -210,6 +214,7 @@
       "oss"
     ],
     "repo": {
+      "clone_url": "https://gitlab.com/szkiba/xk6-banner.git",
       "description": "Print ASCII art banner from k6 test.",
       "homepage": "https://gitlab.com/szkiba/xk6-banner",
       "license": "MIT",
@@ -238,6 +243,7 @@
       "oss"
     ],
     "repo": {
+      "clone_url": "https://github.com/grafana/k6.git",
       "description": "A modern load testing tool, using Go and JavaScript - https://k6.io",
       "homepage": "https://github.com/grafana/k6",
       "license": "AGPL-3.0",

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -180,6 +180,10 @@ The `timestamp` property contains the timestamp of the last modification of the 
 
 Its value depends on the repository manager, in the case of GitHub it contains the time of the last push operation, in the case of GitLab the time of the last repository activity.
 
+#### Clone URL
+
+The `clone_url` property contains a (typically HTTP) URL, which is used to clone the repository.
+
 ## Registry Processing
 
 The source of the registry is a YAML file optimized for human use. Since collecting extension metadata is a complicated and time-consuming task, it is advisable to extract this step into a registry generator CLI tool. The output of this tool is an extension registry in JSON format.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -174,6 +174,12 @@ The `true` value of the `archived` flag indicates that the repository is archive
 
 If a repository is archived, it usually means that the owner has no intention of maintaining it. Such extensions should be removed from the registry.
 
+#### Timestamp
+
+The `timestamp` property contains the timestamp of the last modification of the repository in UNIX time format (the number of non-leap seconds that have elapsed since 00:00:00 UTC on 1st January 1970).
+
+Its value depends on the repository manager, in the case of GitHub it contains the time of the last push operation, in the case of GitLab the time of the last repository activity.
+
 ## Registry Processing
 
 The source of the registry is a YAML file optimized for human use. Since collecting extension metadata is a complicated and time-consuming task, it is advisable to extract this step into a registry generator CLI tool. The output of this tool is an extension registry in JSON format.

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -153,6 +153,11 @@
           "type": "boolean",
           "default": "false",
           "description": "Archived repository flag.\n\nA `true` value indicates that the repository is archived, read only.\n\nIf a repository is archived, it usually means that the owner has no intention of maintaining it. Such extensions should be removed from the registry.\n"
+        },
+        "timestamp": {
+          "type": "number",
+          "default": 0,
+          "description": "Last modification timestamp.\n\nThe timestamp property contains the timestamp of the last modification of the repository in UNIX time format (the number of non-leap seconds that have elapsed since 00:00:00 UTC on 1st January 1970).\nIts value depends on the repository manager, in the case of GitHub it contains the time of the last push operation, in the case of GitLab the time of the last repository activity.\n"
         }
       }
     },

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -158,6 +158,12 @@
           "type": "number",
           "default": 0,
           "description": "Last modification timestamp.\n\nThe timestamp property contains the timestamp of the last modification of the repository in UNIX time format (the number of non-leap seconds that have elapsed since 00:00:00 UTC on 1st January 1970).\nIts value depends on the repository manager, in the case of GitHub it contains the time of the last push operation, in the case of GitLab the time of the last repository activity.\n"
+        },
+        "clone_url": {
+          "type": "string",
+          "format": "uri",
+          "default": "",
+          "description": "URL for the git clone operation.\n\nThe clone_url property contains a (typically HTTP) URL, which is used to clone the repository.\n"
         }
       }
     },

--- a/docs/registry.schema.yaml
+++ b/docs/registry.schema.yaml
@@ -223,6 +223,14 @@ $defs:
 
           The timestamp property contains the timestamp of the last modification of the repository in UNIX time format (the number of non-leap seconds that have elapsed since 00:00:00 UTC on 1st January 1970).
           Its value depends on the repository manager, in the case of GitHub it contains the time of the last push operation, in the case of GitLab the time of the last repository activity.
+      clone_url:
+        type: string
+        format: uri
+        default: ""
+        description: |
+          URL for the git clone operation.
+
+          The clone_url property contains a (typically HTTP) URL, which is used to clone the repository.
   tier:
     type: string
     enum: ["official", "partner", "community"]

--- a/docs/registry.schema.yaml
+++ b/docs/registry.schema.yaml
@@ -215,6 +215,14 @@ $defs:
           A `true` value indicates that the repository is archived, read only.
 
           If a repository is archived, it usually means that the owner has no intention of maintaining it. Such extensions should be removed from the registry.
+      timestamp:
+        type: number
+        default: 0
+        description: |
+          Last modification timestamp.
+
+          The timestamp property contains the timestamp of the last modification of the repository in UNIX time format (the number of non-leap seconds that have elapsed since 00:00:00 UTC on 1st January 1970).
+          Its value depends on the repository manager, in the case of GitHub it contains the time of the last push operation, in the case of GitLab the time of the last repository activity.
   tier:
     type: string
     enum: ["official", "partner", "community"]

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -163,6 +163,13 @@ type Repository struct {
 	//
 	Archived bool `json:"archived,omitempty" yaml:"archived,omitempty" mapstructure:"archived,omitempty"`
 
+	// URL for the git clone operation.
+	//
+	// The clone_url property contains a (typically HTTP) URL, which is used to clone
+	// the repository.
+	//
+	CloneUrl string `json:"clone_url,omitempty" yaml:"clone_url,omitempty" mapstructure:"clone_url,omitempty"`
+
 	// Repository description.
 	//
 	Description string `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -200,6 +200,17 @@ type Repository struct {
 	//
 	Stars int `json:"stars,omitempty" yaml:"stars,omitempty" mapstructure:"stars,omitempty"`
 
+	// Last modification timestamp.
+	//
+	// The timestamp property contains the timestamp of the last modification of the
+	// repository in UNIX time format (the number of non-leap seconds that have
+	// elapsed since 00:00:00 UTC on 1st January 1970).
+	// Its value depends on the repository manager, in the case of GitHub it contains
+	// the time of the last push operation, in the case of GitLab the time of the last
+	// repository activity.
+	//
+	Timestamp float64 `json:"timestamp,omitempty" yaml:"timestamp,omitempty" mapstructure:"timestamp,omitempty"`
+
 	// Repository topics.
 	//
 	// Topics make it easier to find the repository. It is recommended to set the xk6

--- a/releases/v0.1.13.md
+++ b/releases/v0.1.13.md
@@ -1,0 +1,7 @@
+k6registry `v0.1.13` is here 🎉!
+
+This is an internal maintenance release.
+
+## Add repo metadata for linter support
+
+Add last modification (`timestamp`) and git clone URL (`clone_url`) repository metadata to support implementation of extension linter.


### PR DESCRIPTION
Added last modification (`timestamp`) and git clone URL (`clone_url`) repository metadata to support implementation of extension linter.

