### PR TITLE
fix: clone_url naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,7 @@ Before you begin, make sure to familiarize yourself with the [Code of Conduct](C
 
 ## Prerequisites
 
-If you have a golang development environment installed, a `go generate` command must be issued after modifying the source files.
-
-The other option is to install the [cdo] tool and perform the tasks described here. The [cdo] tool can most conveniently be installed using the [eget] tool.
+The tools listed in the [tools] section should be installed before contributing. It is advisable to first install the [cdo] tool, which can be used to easily perform the tasks described here. The [cdo] tool can most conveniently be installed using the [eget] tool.
 
 ```bash
 eget szkiba/cdo
@@ -44,7 +42,7 @@ The JSON schema of the registry can be found in the [registry.schema.yaml] file,
 
 ```bash
 yq -o=json -P docs/registry.schema.yaml > docs/registry.schema.json
-go-jsonschema -p k6registry --only-models -o registry_gen.go docs/registry.schema.yaml
+go-jsonschema --capitalization URL -p k6registry --only-models -o registry_gen.go docs/registry.schema.yaml
 ```
 
 [registry.schema.json]: docs/registry.schema.json

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -148,13 +148,13 @@ func loadGitHub(ctx context.Context, module string) (*k6registry.Repository, err
 
 	repo.Topics = rep.Topics
 
-	repo.Url = rep.GetHTMLURL()
+	repo.URL = rep.GetHTMLURL()
 	repo.Name = rep.GetName()
 	repo.Owner = rep.GetOwner().GetLogin()
 
 	repo.Homepage = rep.GetHomepage()
 	if len(repo.Homepage) == 0 {
-		repo.Homepage = repo.Url
+		repo.Homepage = repo.URL
 	}
 
 	repo.Archived = rep.GetArchived()
@@ -172,7 +172,7 @@ func loadGitHub(ctx context.Context, module string) (*k6registry.Repository, err
 		repo.Timestamp = float64(ts.Unix())
 	}
 
-	repo.CloneUrl = rep.GetCloneURL()
+	repo.CloneURL = rep.GetCloneURL()
 
 	tags, _, err := client.Repositories.ListTags(ctx, owner, name, &github.ListOptions{PerPage: 100})
 	if err != nil {
@@ -214,12 +214,12 @@ func loadGitLab(ctx context.Context, module string) (*k6registry.Repository, err
 	repo.Description = proj.Description
 	repo.Stars = proj.StarCount
 	repo.Archived = proj.Archived
-	repo.Url = proj.WebURL
+	repo.URL = proj.WebURL
 	repo.Homepage = proj.WebURL
 	repo.Topics = proj.Topics
 	repo.Public = len(proj.Visibility) == 0 || proj.Visibility == gitlab.PublicVisibility
 
-	repo.CloneUrl = proj.HTTPURLToRepo
+	repo.CloneURL = proj.HTTPURLToRepo
 
 	if proj.LastActivityAt != nil {
 		repo.Timestamp = float64(proj.LastActivityAt.Unix())

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -168,7 +168,7 @@ type Repository struct {
 	// The clone_url property contains a (typically HTTP) URL, which is used to clone
 	// the repository.
 	//
-	CloneUrl string `json:"clone_url,omitempty" yaml:"clone_url,omitempty" mapstructure:"clone_url,omitempty"`
+	CloneURL string `json:"clone_url,omitempty" yaml:"clone_url,omitempty" mapstructure:"clone_url,omitempty"`
 
 	// Repository description.
 	//
@@ -230,7 +230,7 @@ type Repository struct {
 	// The URL is provided by the repository manager and can be displayed in a
 	// browser.
 	//
-	Url string `json:"url" yaml:"url" mapstructure:"url"`
+	URL string `json:"url" yaml:"url" mapstructure:"url"`
 
 	// List of supported versions.
 	//


### PR DESCRIPTION
Generate CloneURL name instead of CloneUrl, this is the usual naming in go.