### PR TITLE
fix: file/directory permissions

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -29,7 +29,7 @@ func writeAPI(registry k6registry.Registry, target string) error {
 func writeAPIGroupGlobal(registry k6registry.Registry, target string) error {
 	filename := filepath.Join(target, "registry.schema.json")
 
-	if err := os.WriteFile(filename, k6registry.Schema, 0o600); err != nil {
+	if err := os.WriteFile(filename, k6registry.Schema, permFile); err != nil {
 		return err
 	}
 
@@ -40,21 +40,21 @@ func writeAPIGroupGlobal(registry k6registry.Registry, target string) error {
 		return err
 	}
 
-	return os.WriteFile(filename, data, 0o600)
+	return os.WriteFile(filename, data, permFile)
 }
 
 //nolint:forbidigo
 func writeAPIGroupModule(registry k6registry.Registry, target string) error {
 	base := filepath.Join(target, "module")
 
-	if err := os.MkdirAll(base, 0o750); err != nil {
+	if err := os.MkdirAll(base, permDir); err != nil {
 		return err
 	}
 
 	for _, ext := range registry {
 		dir := filepath.Join(base, ext.Module)
 
-		if err := os.MkdirAll(dir, 0o750); err != nil {
+		if err := os.MkdirAll(dir, permDir); err != nil {
 			return err
 		}
 
@@ -66,7 +66,7 @@ func writeAPIGroupModule(registry k6registry.Registry, target string) error {
 				return err
 			}
 
-			err = os.WriteFile(filename, b, 0o600)
+			err = os.WriteFile(filename, b, permFile)
 			if err != nil {
 				return err
 			}
@@ -79,7 +79,7 @@ func writeAPIGroupModule(registry k6registry.Registry, target string) error {
 			return err
 		}
 
-		if err = os.WriteFile(filename, data, 0o600); err != nil {
+		if err = os.WriteFile(filename, data, permFile); err != nil {
 			return err
 		}
 	}
@@ -107,7 +107,7 @@ func writeAPIGroupSubset(registry k6registry.Registry, target string) error {
 func writeAPISubsetProduct(registry k6registry.Registry, target string) error {
 	base := filepath.Join(target, "product")
 
-	if err := os.MkdirAll(base, 0o750); err != nil {
+	if err := os.MkdirAll(base, permDir); err != nil {
 		return err
 	}
 
@@ -131,7 +131,7 @@ func writeAPISubsetProduct(registry k6registry.Registry, target string) error {
 			return err
 		}
 
-		err = os.WriteFile(filepath.Join(base, string(prod)+".json"), data, 0o600)
+		err = os.WriteFile(filepath.Join(base, string(prod)+".json"), data, permFile)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func writeAPISubsetProduct(registry k6registry.Registry, target string) error {
 func writeAPISubsetTier(registry k6registry.Registry, target string) error {
 	base := filepath.Join(target, "tier")
 
-	if err := os.MkdirAll(base, 0o750); err != nil {
+	if err := os.MkdirAll(base, permDir); err != nil {
 		return err
 	}
 
@@ -170,7 +170,7 @@ func writeAPISubsetTier(registry k6registry.Registry, target string) error {
 			return err
 		}
 
-		err = os.WriteFile(filepath.Join(base, string(tier)+".json"), data, 0o600)
+		err = os.WriteFile(filepath.Join(base, string(tier)+".json"), data, permFile)
 		if err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func writeAPISubsetTier(registry k6registry.Registry, target string) error {
 func writeAPISubsetGrade(registry k6registry.Registry, target string) error {
 	base := filepath.Join(target, "grade")
 
-	if err := os.MkdirAll(base, 0o750); err != nil {
+	if err := os.MkdirAll(base, permDir); err != nil {
 		return err
 	}
 
@@ -213,7 +213,7 @@ func writeAPISubsetGrade(registry k6registry.Registry, target string) error {
 			return err
 		}
 
-		err = os.WriteFile(filepath.Join(base, string(grade)+".json"), data, 0o600)
+		err = os.WriteFile(filepath.Join(base, string(grade)+".json"), data, permFile)
 		if err != nil {
 			return err
 		}
@@ -226,7 +226,7 @@ func writeAPISubsetGrade(registry k6registry.Registry, target string) error {
 func writeAPISubsetGradePassing(registry k6registry.Registry, target string) error {
 	base := filepath.Join(target, "grade", "passing")
 
-	if err := os.MkdirAll(base, 0o750); err != nil {
+	if err := os.MkdirAll(base, permDir); err != nil {
 		return err
 	}
 
@@ -262,7 +262,7 @@ func writeAPISubsetGradePassing(registry k6registry.Registry, target string) err
 			return err
 		}
 
-		err = os.WriteFile(filepath.Join(base, string(grade)+".json"), data, 0o600)
+		err = os.WriteFile(filepath.Join(base, string(grade)+".json"), data, permFile)
 		if err != nil {
 			return err
 		}
@@ -275,7 +275,7 @@ func writeAPISubsetGradePassing(registry k6registry.Registry, target string) err
 func writeAPISubsetCategory(registry k6registry.Registry, target string) error {
 	base := filepath.Join(target, "category")
 
-	if err := os.MkdirAll(base, 0o750); err != nil {
+	if err := os.MkdirAll(base, permDir); err != nil {
 		return err
 	}
 
@@ -303,7 +303,7 @@ func writeAPISubsetCategory(registry k6registry.Registry, target string) error {
 			return err
 		}
 
-		err = os.WriteFile(filepath.Join(base, string(cat)+".json"), data, 0o600)
+		err = os.WriteFile(filepath.Join(base, string(cat)+".json"), data, permFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"io/fs"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -77,7 +78,7 @@ func New() (*cobra.Command, error) {
 //nolint:forbidigo
 func run(ctx context.Context, args []string, opts *options) (result error) {
 	if len(opts.api) != 0 {
-		if err := os.MkdirAll(opts.api, 0o750); err != nil {
+		if err := os.MkdirAll(opts.api, permDir); err != nil {
 			return err
 		}
 
@@ -148,3 +149,8 @@ func run(ctx context.Context, args []string, opts *options) (result error) {
 
 	return nil
 }
+
+const (
+	permFile fs.FileMode = 0o644
+	permDir  fs.FileMode = 0o755
+)

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -46,7 +45,7 @@ func newContext(ctx context.Context, appname string) (context.Context, error) {
 		return nil, err
 	}
 
-	err = os.MkdirAll(cacheDir, syscall.S_IWUSR|syscall.S_IRUSR|syscall.S_IXUSR) //nolint:forbidigo
+	err = os.MkdirAll(cacheDir, permDir) //nolint:forbidigo
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +96,7 @@ func cacheSubDir(ctx context.Context, subdir string) (string, error) {
 	}
 
 	dir := filepath.Join(base, subdir)
-	if err := os.MkdirAll(dir, syscall.S_IWUSR|syscall.S_IRUSR|syscall.S_IXUSR); err != nil {
+	if err := os.MkdirAll(dir, permDir); err != nil {
 		return "", err
 	}
 

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -51,7 +51,7 @@ func saveCompliance(ctx context.Context, module string, comp *k6lint.Compliance)
 
 	filename := filepath.Join(base, module) + ".json"
 
-	if err := os.MkdirAll(filepath.Dir(filename), 0o750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filename), permDir); err != nil {
 		return err
 	}
 
@@ -60,7 +60,7 @@ func saveCompliance(ctx context.Context, module string, comp *k6lint.Compliance)
 		return err
 	}
 
-	return os.WriteFile(filename, data, 0o600)
+	return os.WriteFile(filename, data, permFile)
 }
 
 //nolint:forbidigo

--- a/releases/v0.1.15.md
+++ b/releases/v0.1.15.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.15` is here 🎉!
+
+This is an internal maintenance release.
+
+**Fix file/directory permissions**
+
+`golangci-lint` forces the file permission to be `0o600` and the directory permission to be `0o750`. When k6registry runs as a GitHub action, it runs as the root user, so accessing the generated files from the rest of the workflow is problematic.
+
+In the case of generated files, now the permission set to `0o644`, in the case of a direcotry to `0o755`.


### PR DESCRIPTION
`golangci-lint` forces the file permission to be `0o600` and the directory permission to be `0o750`. When k6registry runs as a GitHub action, it runs as the root user, so accessing the generated files from the rest of the workflow is problematic.

In the case of generated files, now the permission set to `0o644`, in the case of a direcotry to `0o755`.
