### PR TITLE
fix go-git workdir permissions

### DIFF
--- a/releases/v0.1.16.md
+++ b/releases/v0.1.16.md
@@ -1,0 +1,11 @@
+k6registry `v0.1.16` is here 🎉!
+
+This is an internal maintenance release.
+
+**Fix file/directory permissions**
+
+The `go-git` library used to checkout the source of extensions creates certain files readable only for the user. This makes it impossible to cache files created in GitHub action mode between workflow runs.
+
+After the git operations, the workdir file permissions now will be fixed.
+
+In the case of files, now the permission set to `0o644`, in the case of a direcotry to `0o755`.


### PR DESCRIPTION
The `go-git` library used to checkout the source of extensions creates certain files readable only for the user. This makes it impossible to cache files created in GitHub action mode between workflow runs.

After the git operations, the workdir file permissions now will be fixed.

In the case of files, now the permission set to `0o644`, in the case of a direcotry to `0o755`.
