### PR TITLE
fix: cache permission fixed in GH action mode

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -63,24 +63,6 @@ func saveCompliance(ctx context.Context, module string, comp *k6lint.Compliance)
 	return os.WriteFile(filename, data, permFile)
 }
 
-func fixWorkdirPerm(dir string) error {
-	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		var mode fs.FileMode
-
-		if info.IsDir() {
-			mode = permDir
-		} else {
-			mode = permFile
-		}
-
-		return os.Chmod(path, mode) //nolint:forbidigo
-	})
-}
-
 //nolint:forbidigo
 func updateWorkdir(ctx context.Context, dir string, cloneURL string) error {
 	_, err := os.Stat(dir)
@@ -92,11 +74,7 @@ func updateWorkdir(ctx context.Context, dir string, cloneURL string) error {
 
 	if notfound {
 		_, err = git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{URL: cloneURL})
-		if err != nil {
-			return err
-		}
-
-		return fixWorkdirPerm(dir)
+		return err
 	}
 
 	repo, err := git.PlainOpen(dir)
@@ -114,7 +92,7 @@ func updateWorkdir(ctx context.Context, dir string, cloneURL string) error {
 		return err
 	}
 
-	return fixWorkdirPerm(dir)
+	return nil
 }
 
 func checkCompliance(ctx context.Context, module string, cloneURL string, tstamp float64) (*k6lint.Compliance, error) {

--- a/releases/v0.1.17.md
+++ b/releases/v0.1.17.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.17` is here 🎉!
+
+This is an internal maintenance release.
+
+**Fix file/directory permissions**
+
+In GitHub Action mode, the permissions of the cache (XDG_CACHE_HOME) files have been corrected.
+
+In the case of files, now the permission set to `0o644`, in the case of a direcotry to `0o755`.


### PR DESCRIPTION
In GitHub Action mode, the permissions of the cache (XDG_CACHE_HOME) files have been corrected.

In the case of files, now the permission set to `0o644`, in the case of a direcotry to `0o755`.
