### PR TITLE
fix: retry git pull on error

### DIFF
--- a/releases/v0.1.21.md
+++ b/releases/v0.1.21.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.21` is here 🎉!
+
+This is an internal maintenance release.
+
+**Retry git pull on error**
+
+In the git working directory, the file permissions are changed to make the cache persistent in GitHub action mode. As a consequence, the git pull operation will fail (if permissions have actually been changed).
+
+To fix this, if the pull operation fails, the pull operation is repeated after a forced checkout operation.


### PR DESCRIPTION
In the git working directory, the file permissions are changed to make the cache persistent in GitHub action mode. As a consequence, the git pull operation will fail (if permissions have actually been changed).

To fix this, if the pull operation fails, the pull operation is repeated after a forced checkout operation.
