### PR TITLE
fix: use correct uid/gid to avoid cache saving propems in GH action mode

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,8 +1,10 @@
 FROM debian:12.6-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-RUN update-ca-certificates
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && update-ca-certificates && \
+    addgroup --system --gid 127 docker && adduser --uid 1001 --gid 127 --disabled-password runner
 
 COPY k6registry /usr/bin/
+
+USER runner
 
 ENTRYPOINT ["k6registry"]

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,9 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
-	"path/filepath"
 
-	"github.com/adrg/xdg"
 	"github.com/grafana/k6registry"
 	"github.com/spf13/cobra"
 )
@@ -54,9 +52,6 @@ func New(levelVar *slog.LevelVar) (*cobra.Command, error) {
 			}
 
 			return run(cmd.Context(), args, opts)
-		},
-		PostRunE: func(_ *cobra.Command, _ []string) error {
-			return ghActionFixPerm(xdg.CacheHome)
 		},
 	}
 
@@ -169,28 +164,6 @@ func run(ctx context.Context, args []string, opts *options) (result error) {
 	}
 
 	return nil
-}
-
-func ghActionFixPerm(dir string) error {
-	if os.Getenv("GITHUB_ACTIONS") != "true" { //nolint:forbidigo
-		return nil
-	}
-
-	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		var mode fs.FileMode
-
-		if info.IsDir() {
-			mode = permDir
-		} else {
-			mode = permFile
-		}
-
-		return os.Chmod(path, mode) //nolint:forbidigo
-	})
 }
 
 const (

--- a/releases/v0.1.23.md
+++ b/releases/v0.1.23.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.23` is here 🎉!
+
+This is an internal maintenance release.
+
+**Fix cache saving issue**
+
+The GitHub workflow is running with user id `1001` and group id `127`. The k6registry docker container runs with the default user id in debian.  As a consequence, the cache directory created under XDG_CACHE_HOME fails to save.
+
+The solution is to use the same user id and group id as the GitHub workflow in the k6registry docker container (user id: `1001`, group id: `127`).


### PR DESCRIPTION
The GitHub workflow is running with user id `1001` and group id `127`. The k6registry docker container runs with the default user id in debian.  As a consequence, the cache directory created under XDG_CACHE_HOME fails to save.

The solution is to use the same user id and group id as the GitHub workflow in the k6registry docker container (user id: `1001`, group id: `127`).
