### PR TITLE
feat: added testability of generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ name   | reqired | default | description
 in     |   yes   |         | input file name
 out    |    no   |  stdout | output file name
 api    |    no   |         | output directory name
+test   |    no   |         | api path(s) to test after generation
 quiet  |    no   | `false` | no output, only validation
 loose  |    no   | `false` | skip JSON schema validation
 lint   |    no   | `false` | enable built-in linter
@@ -482,6 +483,8 @@ ref    |    no   |         | reference output URL for change detection
 In GitHub action mode, the change can be indicated by comparing the output to a reference output. The reference output URL can be passed in the `ref` action parameter. The `changed` output variable will be `true` or `false` depending on whether the output has changed or not compared to the reference output.
 
 The `api` parameter can be used to specify a directory into which the outputs are written. The `registry.json` file is placed in the root directory. The `extension.json` file and the `badge.svg` file are placed in a directory with the same name as the go module path of the extension (if the `lint` parameter is `true`).
+
+The `test` parameter can be used to test registry and catalog files generated with the `api` parameter. The test is successful if the file is not empty, contains `k6` and at least one extension, and if all extensions meet the minimum requirements (e.g. it has versions).
 
 **Outputs**
 
@@ -521,6 +524,8 @@ The output of the generation will be written to the standard output by default. 
 
 The `--api` flag can be used to specify a directory to which the outputs will be written. The `registry.json` file is placed in the root directory. The `extension.json` file and the `badge.svg` file (if the `--lint` flag is used) are placed in a directory with the same name as the extension's go module path.
 
+The `--test` flag can be used to test registry and catalog files generated with the `--api` flag. The test is successful if the file is not empty, contains `k6` and at least one extension, and if all extensions meet the minimum requirements (e.g. it has versions).
+
 
 ```
 k6registry [flags] [source-file]
@@ -529,15 +534,17 @@ k6registry [flags] [source-file]
 ### Flags
 
 ```
-  -o, --out string   write output to file instead of stdout
-      --api string   write outputs to directory instead of stdout
-  -q, --quiet        no output, only validation
-      --loose        skip JSON schema validation
-      --lint         enable built-in linter
-  -c, --compact      compact instead of pretty-printed output
-      --catalog      generate catalog instead of registry
-  -V, --version      print version
-  -h, --help         help for k6registry
+  -o, --out string     write output to file instead of stdout
+      --api string     write outputs to directory instead of stdout
+      --test strings   test api path(s) (example: /registry.json,/catalog.json)
+  -q, --quiet          no output, only validation
+      --loose          skip JSON schema validation
+      --lint           enable built-in linter
+  -c, --compact        compact instead of pretty-printed output
+      --catalog        generate catalog instead of registry
+  -v, --verbose        verbose logging
+  -V, --version        print version
+  -h, --help           help for k6registry
 ```
 
 <!-- #endregion cli -->

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: reference output URL for change detection
     required: false
 
+  test:
+    description: api path(s) to test after generation
+    required: false
+
 outputs:
   changed:
     description: "true if the output has changed compared to ref"

--- a/cmd/help.md
+++ b/cmd/help.md
@@ -9,3 +9,5 @@ The source is read from file specified as command line argument. If it is missin
 The output of the generation will be written to the standard output by default. The output can be saved to a file using the `-o/--out` flag.
 
 The `--api` flag can be used to specify a directory to which the outputs will be written. The `registry.json` file is placed in the root directory. The `extension.json` file and the `badge.svg` file (if the `--lint` flag is used) are placed in a directory with the same name as the extension's go module path.
+
+The `--test` flag can be used to test registry and catalog files generated with the `--api` flag. The test is successful if the file is not empty, contains `k6` and at least one extension, and if all extensions meet the minimum requirements (e.g. it has versions).

--- a/cmd/k6registry/main.go
+++ b/cmd/k6registry/main.go
@@ -5,7 +5,9 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"strings"
 
+	"github.com/google/shlex"
 	"github.com/grafana/k6registry/cmd"
 	sloglogrus "github.com/samber/slog-logrus/v2"
 	"github.com/sirupsen/logrus"
@@ -100,6 +102,15 @@ func getArgs() []string {
 
 	if out := getenv("INPUT_OUT", ""); len(out) != 0 {
 		args = append(args, "--out", out)
+	}
+
+	if paths := getenv("INPUT_TEST", ""); len(paths) != 0 {
+		parts, err := shlex.Split(paths)
+		if err != nil {
+			paths = strings.Join(parts, ",")
+		}
+
+		args = append(args, "--test", paths)
 	}
 
 	args = append(args, getenv("INPUT_IN", ""))

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cli/go-gh/v2 v2.9.0
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/google/go-github/v62 v62.0.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/grafana/clireadme v0.1.0
 	github.com/grafana/k6lint v0.1.0
 	github.com/narqo/go-badge v0.0.0-20230821190521-c9a75c019a59

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/google/go-github/v62 v62.0.0 h1:/6mGCaRywZz9MuHyw9gD1CwsbmBX8GWsbFkwM
 github.com/google/go-github/v62 v62.0.0/go.mod h1:EMxeUqGJq2xRu9DYBMwel/mr7kZrzUOfQmmpYrZn2a4=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/grafana/clireadme v0.1.0 h1:KYEYSnYdSzmHf3bufaK6fQZ5j4dzvM/T+G6Ba+qNnAM=
 github.com/grafana/clireadme v0.1.0/go.mod h1:Wy4KIG2ZBGMYAYyF9l7qAy+yoJVasqk/txsRgoRI3gc=
 github.com/grafana/k6lint v0.1.0 h1:egUuy8Dmc1Wi5eXBnbGC2QkZIt71KTrOnMr/B5bgkzk=

--- a/releases/v0.1.24.md
+++ b/releases/v0.1.24.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.24` is here 🎉!
+
+This is an internal maintenance release.
+
+**Added testability of generated files**
+
+The generated registry and catalog will play an important role in the k6 binary provisioning subsystem, so it is important that there is no loss of service due to generated files. It is advisable to test the generated files to see if they meet the minimum requirements.
+
+The `--test` flag can be used to test registry and catalog files generated with the `--api` flag. The test is successful if the file is not empty, contains k6 and at least one extension, and if all extensions meet the minimum requirements (e.g. it has versions).


### PR DESCRIPTION
The generated registry and catalog will play an important role in the k6 binary provisioning subsystem, so it is important that there is no loss of service due to generated files. It is advisable to test the generated files to see if they meet the minimum requirements.

The `--test` flag can be used to test registry and catalog files generated with the `--api` flag. The test is successful if the file is not empty, contains k6 and at least one extension, and if all extensions meet the minimum requirements (e.g. it has versions).
