### PR TITLE
fix: change detection in api generation mode

### DIFF
--- a/cmd/k6registry/action.go
+++ b/cmd/k6registry/action.go
@@ -16,7 +16,12 @@ import (
 func emitOutput() error {
 	out := getenv("INPUT_OUT", "")
 	if len(out) == 0 {
-		return nil
+		api := getenv("INPUT_API", "")
+		if len(api) == 0 {
+			return nil
+		}
+
+		out = filepath.Join(api, "registry.json")
 	}
 
 	ref := getenv("INPUT_REF", "")

--- a/releases/v0.1.26.md
+++ b/releases/v0.1.26.md
@@ -1,0 +1,7 @@
+k6registry `v0.1.26` is here 🎉!
+
+This is an internal maintenance release.
+
+**Fix change detection**
+
+The use of the `out` parameter was a prerequisite for change detection in GitHub Actions mode. If the `api` parameter is used, the `out` parameter is not required. As a result, when using the `api` parameter, change detection did not work until now. This issue is fixed in this release. Change detection now works when using the `api` parameter in GitHub Actions mode.


### PR DESCRIPTION
The use of the `out` parameter was a prerequisite for change detection in GitHub Actions mode. If the `api` parameter is used, the `out` parameter is not required. As a result, when using the `api` parameter, change detection did not work until now. This issue is fixed in this release. Change detection now works when using the `api` parameter in GitHub Actions mode.