### PR TITLE
Support for manual version number configuration

### DIFF
--- a/cmd/legacy.go
+++ b/cmd/legacy.go
@@ -80,7 +80,7 @@ func legacyConvert(ctx context.Context) error {
 
 		legacyPatch(ext)
 
-		repo, tags, err := loadRepository(ctx, ext.Module)
+		repo, tags, err := loadRepository(ctx, ext)
 		if err != nil {
 			return err
 		}

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -71,6 +71,8 @@ func load(ctx context.Context, in io.Reader, loose bool, lint bool) (k6registry.
 			registry[idx].Categories = append(registry[idx].Categories, k6registry.CategoryMisc)
 		}
 
+		ext := ext
+
 		repo, tags, err := loadRepository(ctx, &ext)
 		if err != nil {
 			return nil, err

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -71,11 +71,7 @@ func load(ctx context.Context, in io.Reader, loose bool, lint bool) (k6registry.
 			registry[idx].Categories = append(registry[idx].Categories, k6registry.CategoryMisc)
 		}
 
-		if ext.Repo != nil {
-			continue
-		}
-
-		repo, tags, err := loadRepository(ctx, ext.Module)
+		repo, tags, err := loadRepository(ctx, &ext)
 		if err != nil {
 			return nil, err
 		}
@@ -105,8 +101,13 @@ func load(ctx context.Context, in io.Reader, loose bool, lint bool) (k6registry.
 	return registry, nil
 }
 
-func loadRepository(ctx context.Context, module string) (*k6registry.Repository, []string, error) {
-	slog.Debug("Loading repository", "module", module)
+func loadRepository(ctx context.Context, ext *k6registry.Extension) (*k6registry.Repository, []string, error) {
+	if ext.Versions != nil {
+		return ext.Repo, ext.Versions, nil
+	}
+
+	module := ext.Module
+
 	if strings.HasPrefix(module, k6Module) || strings.HasPrefix(module, ghModulePrefix) {
 		repo, tags, err := loadGitHub(ctx, module)
 		if err != nil {
@@ -150,6 +151,8 @@ func filterVersions(tags []string) []string {
 }
 
 func loadGitHub(ctx context.Context, module string) (*k6registry.Repository, []string, error) {
+	slog.Debug("Loading GitHub repository", "module", module)
+
 	client, err := contextGitHubClient(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -217,6 +220,8 @@ func loadGitHub(ctx context.Context, module string) (*k6registry.Repository, []s
 }
 
 func loadGitLab(ctx context.Context, module string) (*k6registry.Repository, []string, error) {
+	slog.Debug("Loading GitLab repository", "module", module)
+
 	client, err := gitlab.NewClient("")
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Instead of using the repository manager API, it should be possible to manually configure the versions of the extensions. On the one hand, the API of the less common repository managers is not worth supporting, on the other hand, in some cases it may be necessary to control the allowed versions.

If the `versions` property is specified for an extension in the registry source, it overwrites the automatic version detection.
