### PR TITLE
Update versions from arbitrary git repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,15 @@ mdcode update README.md
 ```
 
 [example.yaml]: docs/example.yaml
-[registry.schema.yaml]: docs/example.schema.yaml
 [registry.md]: docs/registry.md
 [README.md]: README.md
+
+## custom - Update custom example
+
+```bash
+go run ./cmd/k6registry --lint -o docs/custom.json docs/custom.yaml
+go run ./cmd/k6registry --lint --catalog -o docs/custom-catalog.json docs/custom.yaml
+```
 
 ## readme - Update README.md
 

--- a/docs/custom-catalog.json
+++ b/docs/custom-catalog.json
@@ -1,0 +1,183 @@
+{
+  "k6": {
+    "categories": [
+      "misc"
+    ],
+    "description": "A modern load testing tool, using Go and JavaScript",
+    "imports": [
+      "k6"
+    ],
+    "module": "go.k6.io/k6",
+    "products": [
+      "cloud",
+      "oss"
+    ],
+    "repo": {
+      "description": "A modern load testing tool, using Go and JavaScript - https://k6.io",
+      "homepage": "https://github.com/grafana/k6",
+      "license": "AGPL-3.0",
+      "name": "k6",
+      "owner": "grafana",
+      "public": true,
+      "topics": [
+        "es6",
+        "go",
+        "golang",
+        "hacktoberfest",
+        "javascript",
+        "load-generator",
+        "load-testing",
+        "performance"
+      ],
+      "url": "https://github.com/grafana/k6"
+    },
+    "tier": "official",
+    "versions": [
+      "v0.53.0",
+      "v0.52.0",
+      "v0.51.0",
+      "v0.50.0",
+      "v0.49.0",
+      "v0.48.0",
+      "v0.47.0",
+      "v0.46.0",
+      "v0.45.1",
+      "v0.45.0",
+      "v0.44.1",
+      "v0.44.0",
+      "v0.43.1",
+      "v0.43.0",
+      "v0.42.0",
+      "v0.41.0",
+      "v0.40.0",
+      "v0.39.0",
+      "v0.38.3",
+      "v0.38.2",
+      "v0.38.1",
+      "v0.38.0",
+      "v0.37.0",
+      "v0.36.0",
+      "v0.35.0",
+      "v0.34.1",
+      "v0.34.0",
+      "v0.33.0",
+      "v0.32.0",
+      "v0.31.1",
+      "v0.31.0",
+      "v0.30.0",
+      "v0.29.0",
+      "v0.28.0",
+      "v0.27.1",
+      "v0.27.0",
+      "v0.26.2",
+      "v0.26.1",
+      "v0.26.0",
+      "v0.25.1",
+      "v0.25.0",
+      "v0.24.0",
+      "v0.23.1",
+      "v0.23.0",
+      "v0.22.1",
+      "v0.22.0",
+      "v0.21.1",
+      "v0.21.0",
+      "v0.20.0",
+      "v0.19.0",
+      "v0.18.2",
+      "v0.18.1",
+      "v0.18.0",
+      "v0.17.2",
+      "v0.17.1",
+      "v0.17.0",
+      "v0.16.0",
+      "v0.15.0",
+      "v0.14.0",
+      "v0.13.0",
+      "v0.12.2",
+      "v0.12.1",
+      "v0.11.0",
+      "v0.10.0",
+      "v0.9.3",
+      "v0.9.2",
+      "v0.9.1",
+      "v0.9.0",
+      "v0.8.5",
+      "v0.8.4",
+      "v0.8.3",
+      "v0.8.2",
+      "v0.8.1",
+      "v0.8.0",
+      "v0.7.0",
+      "v0.6.0",
+      "v0.5.2",
+      "v0.5.1",
+      "v0.5.0",
+      "v0.4.5",
+      "v0.4.4",
+      "v0.4.3",
+      "v0.4.2",
+      "v0.4.1",
+      "v0.4.0",
+      "v0.3.0",
+      "v0.2.1",
+      "v0.2.0",
+      "v0.0.2",
+      "v0.0.1"
+    ]
+  },
+  "k6/x/codename": {
+    "categories": [
+      "misc"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Generate random, pronounceable codenames",
+    "imports": [
+      "k6/x/codename"
+    ],
+    "module": "codeberg.org/szkiba/xk6-codename",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "https://codeberg.org/szkiba/xk6-codename.git",
+      "name": "xk6-codename",
+      "owner": "szkiba",
+      "url": "https://codeberg.org/szkiba/xk6-codename"
+    },
+    "tier": "community",
+    "versions": [
+      "v0.1.0"
+    ]
+  },
+  "k6/x/sqids": {
+    "categories": [
+      "misc"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Generate short unique identifiers from numbers",
+    "imports": [
+      "k6/x/sqids"
+    ],
+    "module": "bitbucket.org/szkiba/xk6-sqids",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "git@bitbucket.org:szkiba/xk6-sqids.git",
+      "name": "xk6-sqids",
+      "owner": "szkiba",
+      "url": "https://bitbucket.org/szkiba/xk6-sqids"
+    },
+    "tier": "community",
+    "versions": [
+      "v0.1.0",
+      "v0.1.1"
+    ]
+  }
+}

--- a/docs/custom.json
+++ b/docs/custom.json
@@ -1,0 +1,183 @@
+[
+  {
+    "categories": [
+      "misc"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Generate random, pronounceable codenames",
+    "imports": [
+      "k6/x/codename"
+    ],
+    "module": "codeberg.org/szkiba/xk6-codename",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "https://codeberg.org/szkiba/xk6-codename.git",
+      "name": "xk6-codename",
+      "owner": "szkiba",
+      "url": "https://codeberg.org/szkiba/xk6-codename"
+    },
+    "tier": "community",
+    "versions": [
+      "v0.1.0"
+    ]
+  },
+  {
+    "categories": [
+      "misc"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Generate short unique identifiers from numbers",
+    "imports": [
+      "k6/x/sqids"
+    ],
+    "module": "bitbucket.org/szkiba/xk6-sqids",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "git@bitbucket.org:szkiba/xk6-sqids.git",
+      "name": "xk6-sqids",
+      "owner": "szkiba",
+      "url": "https://bitbucket.org/szkiba/xk6-sqids"
+    },
+    "tier": "community",
+    "versions": [
+      "v0.1.0",
+      "v0.1.1"
+    ]
+  },
+  {
+    "categories": [
+      "misc"
+    ],
+    "description": "A modern load testing tool, using Go and JavaScript",
+    "imports": [
+      "k6"
+    ],
+    "module": "go.k6.io/k6",
+    "products": [
+      "cloud",
+      "oss"
+    ],
+    "repo": {
+      "description": "A modern load testing tool, using Go and JavaScript - https://k6.io",
+      "homepage": "https://github.com/grafana/k6",
+      "license": "AGPL-3.0",
+      "name": "k6",
+      "owner": "grafana",
+      "public": true,
+      "topics": [
+        "es6",
+        "go",
+        "golang",
+        "hacktoberfest",
+        "javascript",
+        "load-generator",
+        "load-testing",
+        "performance"
+      ],
+      "url": "https://github.com/grafana/k6"
+    },
+    "tier": "official",
+    "versions": [
+      "v0.53.0",
+      "v0.52.0",
+      "v0.51.0",
+      "v0.50.0",
+      "v0.49.0",
+      "v0.48.0",
+      "v0.47.0",
+      "v0.46.0",
+      "v0.45.1",
+      "v0.45.0",
+      "v0.44.1",
+      "v0.44.0",
+      "v0.43.1",
+      "v0.43.0",
+      "v0.42.0",
+      "v0.41.0",
+      "v0.40.0",
+      "v0.39.0",
+      "v0.38.3",
+      "v0.38.2",
+      "v0.38.1",
+      "v0.38.0",
+      "v0.37.0",
+      "v0.36.0",
+      "v0.35.0",
+      "v0.34.1",
+      "v0.34.0",
+      "v0.33.0",
+      "v0.32.0",
+      "v0.31.1",
+      "v0.31.0",
+      "v0.30.0",
+      "v0.29.0",
+      "v0.28.0",
+      "v0.27.1",
+      "v0.27.0",
+      "v0.26.2",
+      "v0.26.1",
+      "v0.26.0",
+      "v0.25.1",
+      "v0.25.0",
+      "v0.24.0",
+      "v0.23.1",
+      "v0.23.0",
+      "v0.22.1",
+      "v0.22.0",
+      "v0.21.1",
+      "v0.21.0",
+      "v0.20.0",
+      "v0.19.0",
+      "v0.18.2",
+      "v0.18.1",
+      "v0.18.0",
+      "v0.17.2",
+      "v0.17.1",
+      "v0.17.0",
+      "v0.16.0",
+      "v0.15.0",
+      "v0.14.0",
+      "v0.13.0",
+      "v0.12.2",
+      "v0.12.1",
+      "v0.11.0",
+      "v0.10.0",
+      "v0.9.3",
+      "v0.9.2",
+      "v0.9.1",
+      "v0.9.0",
+      "v0.8.5",
+      "v0.8.4",
+      "v0.8.3",
+      "v0.8.2",
+      "v0.8.1",
+      "v0.8.0",
+      "v0.7.0",
+      "v0.6.0",
+      "v0.5.2",
+      "v0.5.1",
+      "v0.5.0",
+      "v0.4.5",
+      "v0.4.4",
+      "v0.4.3",
+      "v0.4.2",
+      "v0.4.1",
+      "v0.4.0",
+      "v0.3.0",
+      "v0.2.1",
+      "v0.2.0",
+      "v0.0.2",
+      "v0.0.1"
+    ]
+  }
+]

--- a/docs/custom.yaml
+++ b/docs/custom.yaml
@@ -1,0 +1,25 @@
+- module: codeberg.org/szkiba/xk6-codename
+  description: Generate random, pronounceable codenames
+  imports:
+    - k6/x/codename
+  categories:
+    - misc
+  versions:
+    - v0.1.0
+  repo:
+    name: xk6-codename
+    owner: szkiba
+    url: https://codeberg.org/szkiba/xk6-codename
+    clone_url: https://codeberg.org/szkiba/xk6-codename.git
+
+- module: bitbucket.org/szkiba/xk6-sqids
+  description: Generate short unique identifiers from numbers
+  imports:
+    - k6/x/sqids
+  categories:
+    - misc
+  repo:
+    name: xk6-sqids
+    owner: szkiba
+    url: https://bitbucket.org/szkiba/xk6-sqids
+    clone_url: git@bitbucket.org:szkiba/xk6-sqids.git

--- a/releases/v0.1.27.md
+++ b/releases/v0.1.27.md
@@ -1,0 +1,20 @@
+k6registry `v0.1.27` is here 🎉!
+
+This is an internal maintenance release.
+
+- Support for manual version number configuration
+- Update versions from arbitrary git repository
+
+
+**Support for manual version number configuration**
+
+Instead of using the repository manager API, it is possible to manually configure the versions of the extensions. The API of the less common repository managers is not worth supporting, on the other hand, in some cases it may be necessary to control the allowed versions.
+
+If the versions property is specified for an extension in the registry source, it overwrites the automatic version detection.
+
+**Update versions from arbitrary git repository**
+
+The API of the less common repository managers is not worth supporting, rather the available version numbers are detected with local git operations after cloning/pulling the git repository.
+
+The cache directory used for compliance checks, where the git repositories are kept up-to-date, is also used to detect versions (tags).
+


### PR DESCRIPTION
The API of the less common repository managers is not worth supporting, rather the available version numbers are detected with local git operations after cloning/pulling the git repository.

The cache directory used for compliance checks, where the git repositories are kept up-to-date, is also used to detect versions (tags).

