### PR TITLE
feat: Support for import extension properties from other registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,9 @@ mdcode update README.md
 ## custom - Update custom example
 
 ```bash
-go run ./cmd/k6registry --lint -o docs/custom.json docs/custom.yaml
-go run ./cmd/k6registry --lint --catalog -o docs/custom-catalog.json docs/custom.yaml
+export ORIGIN=https://registry.k6.io/registry.json
+go run ./cmd/k6registry --lint -o docs/custom.json --origin $ORIGIN docs/custom.yaml
+go run ./cmd/k6registry --lint --catalog -o docs/custom-catalog.json  --origin $ORIGIN docs/custom.yaml
 ```
 
 ## readme - Update README.md

--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ lint   |    no   | `false` | enable built-in linter
 compact|    no   | `false` | compact instead of pretty-printed output
 catalog|    no   | `false` | generate catalog instead of registry
 ref    |    no   |         | reference output URL for change detection
+origin |    no   |         | external registry URL for default values
 
 In GitHub action mode, the change can be indicated by comparing the output to a reference output. The reference output URL can be passed in the `ref` action parameter. The `changed` output variable will be `true` or `false` depending on whether the output has changed or not compared to the reference output.
 
@@ -534,17 +535,18 @@ k6registry [flags] [source-file]
 ### Flags
 
 ```
-  -o, --out string     write output to file instead of stdout
-      --api string     write outputs to directory instead of stdout
-      --test strings   test api path(s) (example: /registry.json,/catalog.json)
-  -q, --quiet          no output, only validation
-      --loose          skip JSON schema validation
-      --lint           enable built-in linter
-  -c, --compact        compact instead of pretty-printed output
-      --catalog        generate catalog instead of registry
-  -v, --verbose        verbose logging
-  -V, --version        print version
-  -h, --help           help for k6registry
+  -o, --out string      write output to file instead of stdout
+      --api string      write outputs to directory instead of stdout
+      --origin string   external registry URL for default values
+      --test strings    test api path(s) (example: /registry.json,/catalog.json)
+  -q, --quiet           no output, only validation
+      --loose           skip JSON schema validation
+      --lint            enable built-in linter
+  -c, --compact         compact instead of pretty-printed output
+      --catalog         generate catalog instead of registry
+  -v, --verbose         verbose logging
+  -V, --version         print version
+  -h, --help            help for k6registry
 ```
 
 <!-- #endregion cli -->

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: generate catalog instead of registry
     required: false
 
+  origin:
+    description: external registry URL for default values
+    required: false
+
   ref:
     description: reference output URL for change detection
     required: false

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,6 +27,7 @@ type options struct {
 	lint    bool
 	api     string
 	test    []string
+	origin  string
 }
 
 // New creates new cobra command for exec command.
@@ -70,6 +71,7 @@ func New(levelVar *slog.LevelVar) (*cobra.Command, error) {
 
 	flags.StringVarP(&opts.out, "out", "o", "", "write output to file instead of stdout")
 	flags.StringVar(&opts.api, "api", "", "write outputs to directory instead of stdout")
+	flags.StringVar(&opts.origin, "origin", "", "external registry URL for default values")
 	flags.StringSliceVar(&opts.test, "test", []string{}, "test api path(s) (example: /registry.json,/catalog.json)")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "no output, only validation")
 	flags.BoolVar(&opts.loose, "loose", false, "skip JSON schema validation")
@@ -136,7 +138,7 @@ func run(ctx context.Context, args []string, opts *options) (result error) {
 		output = file
 	}
 
-	registry, err := load(ctx, input, opts.loose, opts.lint)
+	registry, err := load(ctx, input, opts.loose, opts.lint, opts.origin)
 	if err != nil {
 		return err
 	}

--- a/cmd/k6registry/main.go
+++ b/cmd/k6registry/main.go
@@ -113,6 +113,10 @@ func getArgs() []string {
 		args = append(args, "--test", paths)
 	}
 
+	if origin := getenv("INPUT_ORIGIN", ""); len(origin) != 0 {
+		args = append(args, "--origin", origin)
+	}
+
 	args = append(args, getenv("INPUT_IN", ""))
 
 	return args

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/grafana/k6registry"
+)
+
+func loadOrigin(ctx context.Context, from string) (map[string]k6registry.Extension, error) {
+	dict := make(map[string]k6registry.Extension, 0)
+
+	if len(from) == 0 {
+		return dict, nil
+	}
+
+	client := &http.Client{Timeout: httpTimeout}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, from, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close() //nolint:errcheck
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var reg k6registry.Registry
+
+	err = json.Unmarshal(data, &reg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ext := range reg {
+		dict[ext.Module] = ext
+	}
+
+	return dict, nil
+}
+
+func fromOrigin(ext *k6registry.Extension, origin map[string]k6registry.Extension, loc string) bool {
+	oext, found := origin[ext.Module]
+	if !found {
+		return false
+	}
+
+	slog.Debug("Import extension", "module", ext.Module, "origin", loc)
+
+	if ext.Compliance == nil {
+		ext.Compliance = oext.Compliance
+	}
+
+	if ext.Repo == nil {
+		ext.Repo = oext.Repo
+	}
+
+	if len(ext.Versions) == 0 {
+		ext.Versions = oext.Versions
+	}
+
+	if len(ext.Description) == 0 {
+		ext.Description = oext.Description
+	}
+
+	if len(ext.Tier) == 0 {
+		ext.Tier = oext.Tier
+	}
+
+	if len(ext.Categories) == 0 {
+		ext.Categories = oext.Categories
+	}
+
+	if len(ext.Products) == 0 {
+		ext.Products = oext.Products
+	}
+
+	if len(ext.Imports) == 0 {
+		ext.Imports = oext.Imports
+	}
+
+	if len(ext.Outputs) == 0 {
+		ext.Outputs = oext.Outputs
+	}
+
+	return true
+}
+
+const httpTimeout = 10 * time.Second

--- a/docs/custom-catalog.json
+++ b/docs/custom-catalog.json
@@ -35,94 +35,7 @@
     "versions": [
       "v0.53.0",
       "v0.52.0",
-      "v0.51.0",
-      "v0.50.0",
-      "v0.49.0",
-      "v0.48.0",
-      "v0.47.0",
-      "v0.46.0",
-      "v0.45.1",
-      "v0.45.0",
-      "v0.44.1",
-      "v0.44.0",
-      "v0.43.1",
-      "v0.43.0",
-      "v0.42.0",
-      "v0.41.0",
-      "v0.40.0",
-      "v0.39.0",
-      "v0.38.3",
-      "v0.38.2",
-      "v0.38.1",
-      "v0.38.0",
-      "v0.37.0",
-      "v0.36.0",
-      "v0.35.0",
-      "v0.34.1",
-      "v0.34.0",
-      "v0.33.0",
-      "v0.32.0",
-      "v0.31.1",
-      "v0.31.0",
-      "v0.30.0",
-      "v0.29.0",
-      "v0.28.0",
-      "v0.27.1",
-      "v0.27.0",
-      "v0.26.2",
-      "v0.26.1",
-      "v0.26.0",
-      "v0.25.1",
-      "v0.25.0",
-      "v0.24.0",
-      "v0.23.1",
-      "v0.23.0",
-      "v0.22.1",
-      "v0.22.0",
-      "v0.21.1",
-      "v0.21.0",
-      "v0.20.0",
-      "v0.19.0",
-      "v0.18.2",
-      "v0.18.1",
-      "v0.18.0",
-      "v0.17.2",
-      "v0.17.1",
-      "v0.17.0",
-      "v0.16.0",
-      "v0.15.0",
-      "v0.14.0",
-      "v0.13.0",
-      "v0.12.2",
-      "v0.12.1",
-      "v0.11.0",
-      "v0.10.0",
-      "v0.9.3",
-      "v0.9.2",
-      "v0.9.1",
-      "v0.9.0",
-      "v0.8.5",
-      "v0.8.4",
-      "v0.8.3",
-      "v0.8.2",
-      "v0.8.1",
-      "v0.8.0",
-      "v0.7.0",
-      "v0.6.0",
-      "v0.5.2",
-      "v0.5.1",
-      "v0.5.0",
-      "v0.4.5",
-      "v0.4.4",
-      "v0.4.3",
-      "v0.4.2",
-      "v0.4.1",
-      "v0.4.0",
-      "v0.3.0",
-      "v0.2.1",
-      "v0.2.0",
-      "v0.0.2",
-      "v0.0.1"
+      "v0.51.0"
     ]
   },
   "k6/x/codename": {
@@ -152,6 +65,42 @@
       "v0.1.0"
     ]
   },
+  "k6/x/faker": {
+    "categories": [
+      "data"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Generate random fake data",
+    "imports": [
+      "k6/x/faker"
+    ],
+    "module": "github.com/grafana/xk6-faker",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "https://github.com/grafana/xk6-faker.git",
+      "description": "Random fake data generator for k6.",
+      "homepage": "https://faker.x.k6.io",
+      "license": "AGPL-3.0",
+      "name": "xk6-faker",
+      "owner": "grafana",
+      "public": true,
+      "stars": 54,
+      "timestamp": 1725533453,
+      "topics": [
+        "xk6"
+      ],
+      "url": "https://github.com/grafana/xk6-faker"
+    },
+    "tier": "official",
+    "versions": [
+      "v0.4.0"
+    ]
+  },
   "k6/x/sqids": {
     "categories": [
       "misc"
@@ -178,6 +127,51 @@
     "versions": [
       "v0.1.0",
       "v0.1.1"
+    ]
+  },
+  "k6/x/sql": {
+    "categories": [
+      "data"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Load-test SQL Servers",
+    "imports": [
+      "k6/x/sql"
+    ],
+    "module": "github.com/grafana/xk6-sql",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "https://github.com/grafana/xk6-sql.git",
+      "description": "k6 extension to load test RDBMSs (PostgreSQL, MySQL, MS SQL and SQLite3)",
+      "homepage": "https://github.com/grafana/xk6-sql",
+      "license": "Apache-2.0",
+      "name": "xk6-sql",
+      "owner": "grafana",
+      "public": true,
+      "stars": 108,
+      "timestamp": 1725979901,
+      "topics": [
+        "k6",
+        "sql",
+        "xk6"
+      ],
+      "url": "https://github.com/grafana/xk6-sql"
+    },
+    "tier": "official",
+    "versions": [
+      "v0.4.1",
+      "v0.4.0",
+      "v0.3.0",
+      "v0.2.1",
+      "v0.2.0",
+      "v0.1.1",
+      "v0.1.0",
+      "v0.0.1"
     ]
   }
 }

--- a/docs/custom.json
+++ b/docs/custom.json
@@ -56,6 +56,87 @@
   },
   {
     "categories": [
+      "data"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Generate random fake data",
+    "imports": [
+      "k6/x/faker"
+    ],
+    "module": "github.com/grafana/xk6-faker",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "https://github.com/grafana/xk6-faker.git",
+      "description": "Random fake data generator for k6.",
+      "homepage": "https://faker.x.k6.io",
+      "license": "AGPL-3.0",
+      "name": "xk6-faker",
+      "owner": "grafana",
+      "public": true,
+      "stars": 54,
+      "timestamp": 1725533453,
+      "topics": [
+        "xk6"
+      ],
+      "url": "https://github.com/grafana/xk6-faker"
+    },
+    "tier": "official",
+    "versions": [
+      "v0.4.0"
+    ]
+  },
+  {
+    "categories": [
+      "data"
+    ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
+    "description": "Load-test SQL Servers",
+    "imports": [
+      "k6/x/sql"
+    ],
+    "module": "github.com/grafana/xk6-sql",
+    "products": [
+      "oss"
+    ],
+    "repo": {
+      "clone_url": "https://github.com/grafana/xk6-sql.git",
+      "description": "k6 extension to load test RDBMSs (PostgreSQL, MySQL, MS SQL and SQLite3)",
+      "homepage": "https://github.com/grafana/xk6-sql",
+      "license": "Apache-2.0",
+      "name": "xk6-sql",
+      "owner": "grafana",
+      "public": true,
+      "stars": 108,
+      "timestamp": 1725979901,
+      "topics": [
+        "k6",
+        "sql",
+        "xk6"
+      ],
+      "url": "https://github.com/grafana/xk6-sql"
+    },
+    "tier": "official",
+    "versions": [
+      "v0.4.1",
+      "v0.4.0",
+      "v0.3.0",
+      "v0.2.1",
+      "v0.2.0",
+      "v0.1.1",
+      "v0.1.0",
+      "v0.0.1"
+    ]
+  },
+  {
+    "categories": [
       "misc"
     ],
     "description": "A modern load testing tool, using Go and JavaScript",
@@ -90,94 +171,7 @@
     "versions": [
       "v0.53.0",
       "v0.52.0",
-      "v0.51.0",
-      "v0.50.0",
-      "v0.49.0",
-      "v0.48.0",
-      "v0.47.0",
-      "v0.46.0",
-      "v0.45.1",
-      "v0.45.0",
-      "v0.44.1",
-      "v0.44.0",
-      "v0.43.1",
-      "v0.43.0",
-      "v0.42.0",
-      "v0.41.0",
-      "v0.40.0",
-      "v0.39.0",
-      "v0.38.3",
-      "v0.38.2",
-      "v0.38.1",
-      "v0.38.0",
-      "v0.37.0",
-      "v0.36.0",
-      "v0.35.0",
-      "v0.34.1",
-      "v0.34.0",
-      "v0.33.0",
-      "v0.32.0",
-      "v0.31.1",
-      "v0.31.0",
-      "v0.30.0",
-      "v0.29.0",
-      "v0.28.0",
-      "v0.27.1",
-      "v0.27.0",
-      "v0.26.2",
-      "v0.26.1",
-      "v0.26.0",
-      "v0.25.1",
-      "v0.25.0",
-      "v0.24.0",
-      "v0.23.1",
-      "v0.23.0",
-      "v0.22.1",
-      "v0.22.0",
-      "v0.21.1",
-      "v0.21.0",
-      "v0.20.0",
-      "v0.19.0",
-      "v0.18.2",
-      "v0.18.1",
-      "v0.18.0",
-      "v0.17.2",
-      "v0.17.1",
-      "v0.17.0",
-      "v0.16.0",
-      "v0.15.0",
-      "v0.14.0",
-      "v0.13.0",
-      "v0.12.2",
-      "v0.12.1",
-      "v0.11.0",
-      "v0.10.0",
-      "v0.9.3",
-      "v0.9.2",
-      "v0.9.1",
-      "v0.9.0",
-      "v0.8.5",
-      "v0.8.4",
-      "v0.8.3",
-      "v0.8.2",
-      "v0.8.1",
-      "v0.8.0",
-      "v0.7.0",
-      "v0.6.0",
-      "v0.5.2",
-      "v0.5.1",
-      "v0.5.0",
-      "v0.4.5",
-      "v0.4.4",
-      "v0.4.3",
-      "v0.4.2",
-      "v0.4.1",
-      "v0.4.0",
-      "v0.3.0",
-      "v0.2.1",
-      "v0.2.0",
-      "v0.0.2",
-      "v0.0.1"
+      "v0.51.0"
     ]
   }
 ]

--- a/docs/custom.yaml
+++ b/docs/custom.yaml
@@ -23,3 +23,15 @@
     owner: szkiba
     url: https://bitbucket.org/szkiba/xk6-sqids
     clone_url: git@bitbucket.org:szkiba/xk6-sqids.git
+
+- module: github.com/grafana/xk6-faker
+  versions:
+    - v0.4.0
+
+- module: github.com/grafana/xk6-sql
+
+- module: go.k6.io/k6
+  versions:
+    - v0.53.0
+    - v0.52.0
+    - v0.51.0

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -137,8 +137,7 @@
         }
       },
       "required": [
-        "module",
-        "description"
+        "module"
       ],
       "additionalProperties": false
     },

--- a/registry.go
+++ b/registry.go
@@ -65,3 +65,17 @@ func RegistryToCatalog(reg Registry) Catalog {
 
 	return catalog
 }
+
+// ModuleReference returns true if only the "Module" property has value.
+func (ext *Extension) ModuleReference() bool {
+	return len(ext.Module) > 0 &&
+		len(ext.Description) == 0 &&
+		len(ext.Imports) == 0 &&
+		len(ext.Outputs) == 0 &&
+		len(ext.Versions) == 0 &&
+		len(ext.Categories) == 0 &&
+		len(ext.Products) == 0 &&
+		len(ext.Tier) == 0 &&
+		ext.Repo == nil &&
+		ext.Compliance == nil
+}

--- a/releases/v0.1.27.md
+++ b/releases/v0.1.27.md
@@ -18,3 +18,8 @@ The API of the less common repository managers is not worth supporting, rather t
 
 The cache directory used for compliance checks, where the git repositories are kept up-to-date, is also used to detect versions (tags).
 
+**Support for import extension properties from other registry**
+
+When creating a custom registry, it is inconvenient (and a potential source of error) to duplicate the data of those extensions that are also included in the registry maintained by Grafana. Support for importing extension data from other registries helps with this.
+
+An optional origin registry URL can be specified with the `--origin` command line flag. If the extension is included in the origin registry, the default values ​​of its properties will be the values ​​specified in the origin registry. To import all the properties, it is enough to specify the `module` property. Properties in the origin registry can be overwritten in the registry source. For example, by specifying the `versions` property, you can specify that only certain versions are included in the generated registry.


### PR DESCRIPTION
When creating a custom registry, it is inconvenient (and a potential source of error) to duplicate the data of those extensions that are also included in the registry maintained by Grafana. Support for importing extension data from other registries helps with this.

An optional origin registry URL can be specified with the `--origin` command line flag. If the extension is included in the origin registry, the default values ​​of its properties will be the values ​​specified in the origin registry. To import all the properties, it is enough to specify the `module` property. Properties in the origin registry can be overwritten in the registry source. For example, by specifying the `versions` property, you can specify that only certain versions are included in the generated registry.
