### PR TITLE
feat: added version constraints support

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,12 +42,19 @@ func writeData(filename string, data []byte) error {
 }
 
 func writeJSON(filename string, source interface{}) error {
-	data, err := json.MarshalIndent(source, "", "  ")
+	var buff bytes.Buffer
+
+	encoder := json.NewEncoder(&buff)
+
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+
+	err := encoder.Encode(source)
 	if err != nil {
 		return err
 	}
 
-	return writeData(filename, data)
+	return writeData(filename, buff.Bytes())
 }
 
 func writeAPIGroupGlobal(registry k6registry.Registry, target string) error {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -165,6 +165,8 @@ func writeOutput(registry k6registry.Registry, output io.Writer, opts *options) 
 		encoder.SetIndent("", "  ")
 	}
 
+	encoder.SetEscapeHTML(false)
+
 	var source interface{} = registry
 
 	if opts.catalog {

--- a/cmd/legacy.go
+++ b/cmd/legacy.go
@@ -87,7 +87,7 @@ func legacyConvert(ctx context.Context) error {
 
 		tmp := *ext
 		tmp.Repo = repo
-		tmp.Versions = filterVersions(tags)
+		tmp.Versions = tagsToVersions(tags)
 
 		if ok, _ := lintExtension(tmp); ok {
 			reg = append(reg, ext)

--- a/cmd/origin.go
+++ b/cmd/origin.go
@@ -71,6 +71,10 @@ func fromOrigin(ext *k6registry.Extension, origin map[string]k6registry.Extensio
 		ext.Versions = oext.Versions
 	}
 
+	if len(ext.Constraints) == 0 {
+		ext.Constraints = oext.Constraints
+	}
+
 	if len(ext.Description) == 0 {
 		ext.Description = oext.Description
 	}

--- a/docs/custom-catalog.json
+++ b/docs/custom-catalog.json
@@ -3,6 +3,7 @@
     "categories": [
       "misc"
     ],
+    "constraints": ">=v0.50.0",
     "description": "A modern load testing tool, using Go and JavaScript",
     "imports": [
       "k6"
@@ -35,7 +36,8 @@
     "versions": [
       "v0.53.0",
       "v0.52.0",
-      "v0.51.0"
+      "v0.51.0",
+      "v0.50.0"
     ]
   },
   "k6/x/codename": {
@@ -69,10 +71,7 @@
     "categories": [
       "data"
     ],
-    "compliance": {
-      "grade": "A",
-      "level": 100
-    },
+    "constraints": ">=v0.4.0",
     "description": "Generate random fake data",
     "imports": [
       "k6/x/faker"
@@ -133,10 +132,6 @@
     "categories": [
       "data"
     ],
-    "compliance": {
-      "grade": "A",
-      "level": 100
-    },
     "description": "Load-test SQL Servers",
     "imports": [
       "k6/x/sql"
@@ -153,7 +148,7 @@
       "name": "xk6-sql",
       "owner": "grafana",
       "public": true,
-      "stars": 108,
+      "stars": 109,
       "timestamp": 1725979901,
       "topics": [
         "k6",

--- a/docs/custom.json
+++ b/docs/custom.json
@@ -58,10 +58,7 @@
     "categories": [
       "data"
     ],
-    "compliance": {
-      "grade": "A",
-      "level": 100
-    },
+    "constraints": ">=v0.4.0",
     "description": "Generate random fake data",
     "imports": [
       "k6/x/faker"
@@ -94,10 +91,6 @@
     "categories": [
       "data"
     ],
-    "compliance": {
-      "grade": "A",
-      "level": 100
-    },
     "description": "Load-test SQL Servers",
     "imports": [
       "k6/x/sql"
@@ -114,7 +107,7 @@
       "name": "xk6-sql",
       "owner": "grafana",
       "public": true,
-      "stars": 108,
+      "stars": 109,
       "timestamp": 1725979901,
       "topics": [
         "k6",
@@ -139,6 +132,7 @@
     "categories": [
       "misc"
     ],
+    "constraints": ">=v0.50.0",
     "description": "A modern load testing tool, using Go and JavaScript",
     "imports": [
       "k6"
@@ -171,7 +165,8 @@
     "versions": [
       "v0.53.0",
       "v0.52.0",
-      "v0.51.0"
+      "v0.51.0",
+      "v0.50.0"
     ]
   }
 ]

--- a/docs/custom.yaml
+++ b/docs/custom.yaml
@@ -25,13 +25,9 @@
     clone_url: git@bitbucket.org:szkiba/xk6-sqids.git
 
 - module: github.com/grafana/xk6-faker
-  versions:
-    - v0.4.0
+  constraints: ">=v0.4.0"
 
 - module: github.com/grafana/xk6-sql
 
 - module: go.k6.io/k6
-  versions:
-    - v0.53.0
-    - v0.52.0
-    - v0.51.0
+  constraints: ">=v0.50.0"

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -63,6 +63,7 @@
         },
         "description": {
           "type": "string",
+          "default": "",
           "description": "Brief description of the extension.\n",
           "examples": [
             "This is a very cool extension, it displays the message 'Hello World!'"
@@ -79,6 +80,18 @@
               "v0.1.0",
               "v0.2.0",
               "v0.2.1"
+            ]
+          ]
+        },
+        "constraints": {
+          "type": "string",
+          "pattern": "[vxX*|,&\\^0-9.+-><=, ~]+",
+          "default": "",
+          "description": "Version constraints.\n\nVersion constraints are primarily used to filter automatically detected versions.\nIt can also be used to filter the versions property imported from the origin registry.\n",
+          "examples": [
+            [
+              ">=v0.4.0",
+              ">v0.50.0"
             ]
           ]
         },

--- a/registry.go
+++ b/registry.go
@@ -65,17 +65,3 @@ func RegistryToCatalog(reg Registry) Catalog {
 
 	return catalog
 }
-
-// ModuleReference returns true if only the "Module" property has value.
-func (ext *Extension) ModuleReference() bool {
-	return len(ext.Module) > 0 &&
-		len(ext.Description) == 0 &&
-		len(ext.Imports) == 0 &&
-		len(ext.Outputs) == 0 &&
-		len(ext.Versions) == 0 &&
-		len(ext.Categories) == 0 &&
-		len(ext.Products) == 0 &&
-		len(ext.Tier) == 0 &&
-		ext.Repo == nil &&
-		ext.Compliance == nil
-}

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -70,9 +70,18 @@ type Extension struct {
 	//
 	Compliance *Compliance `json:"compliance,omitempty" yaml:"compliance,omitempty" mapstructure:"compliance,omitempty"`
 
+	// Version constraints.
+	//
+	// Version constraints are primarily used to filter automatically detected
+	// versions.
+	// It can also be used to filter the versions property imported from the origin
+	// registry.
+	//
+	Constraints string `json:"constraints,omitempty" yaml:"constraints,omitempty" mapstructure:"constraints,omitempty"`
+
 	// Brief description of the extension.
 	//
-	Description string `json:"description" yaml:"description" mapstructure:"description"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// List of JavaScript import paths registered by the extension.
 	//

--- a/releases/v0.1.28.md
+++ b/releases/v0.1.28.md
@@ -1,0 +1,7 @@
+k6registry `v0.1.28` is here 🎉!
+
+This is an internal maintenance release.
+
+**Add version constraints support**
+
+Version constraints are primarily used to filter automatically detected versions. It can also be used to filter the versions property imported from the origin registry.


### PR DESCRIPTION
Version constraints are primarily used to filter automatically detected versions. It can also be used to filter the versions property imported from the origin registry.
