### PR TITLE
feat: generate catalog and registry at the same time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,7 @@ go-jsonschema --capitalization URL --capitalization OSS -p k6registry --only-mod
 The example registry can be found in [example.yaml] file, the documentation ([registry.md], [README.md]) must be updated after modification.
 
 ```bash
-go run ./cmd/k6registry --lint -o docs/example.json docs/example.yaml
-go run ./cmd/k6registry --lint --catalog -o docs/example-catalog.json docs/example.yaml
+go run ./cmd/k6registry --lint -o docs/example.json --catalog docs/example-catalog.json docs/example.yaml
 go run ./cmd/k6registry --lint -q --api docs/example-api docs/example.yaml
 tree -n --noreport --filesfirst -o docs/example-api.txt docs/example-api 
 mdcode update docs/registry.md
@@ -69,8 +68,7 @@ mdcode update README.md
 
 ```bash
 export ORIGIN=https://registry.k6.io/registry.json
-go run ./cmd/k6registry --lint -o docs/custom.json --origin $ORIGIN docs/custom.yaml
-go run ./cmd/k6registry --lint --catalog -o docs/custom-catalog.json  --origin $ORIGIN docs/custom.yaml
+go run ./cmd/k6registry --lint --catalog docs/custom-catalog.json -o docs/custom.json --origin $ORIGIN docs/custom.yaml
 ```
 
 ## readme - Update README.md

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ quiet  |    no   | `false` | no output, only validation
 loose  |    no   | `false` | skip JSON schema validation
 lint   |    no   | `false` | enable built-in linter
 compact|    no   | `false` | compact instead of pretty-printed output
-catalog|    no   | `false` | generate catalog instead of registry
+catalog|    no   |         | generate catalog to the specified file
 ref    |    no   |         | reference output URL for change detection
 origin |    no   |         | external registry URL for default values
 
@@ -535,18 +535,18 @@ k6registry [flags] [source-file]
 ### Flags
 
 ```
-  -o, --out string      write output to file instead of stdout
-      --api string      write outputs to directory instead of stdout
-      --origin string   external registry URL for default values
-      --test strings    test api path(s) (example: /registry.json,/catalog.json)
-  -q, --quiet           no output, only validation
-      --loose           skip JSON schema validation
-      --lint            enable built-in linter
-  -c, --compact         compact instead of pretty-printed output
-      --catalog         generate catalog instead of registry
-  -v, --verbose         verbose logging
-  -V, --version         print version
-  -h, --help            help for k6registry
+  -o, --out string       write output to file instead of stdout
+      --api string       write outputs to directory instead of stdout
+      --origin string    external registry URL for default values
+      --test strings     test api path(s) (example: /registry.json,/catalog.json)
+  -q, --quiet            no output, only validation
+      --loose            skip JSON schema validation
+      --lint             enable built-in linter
+  -c, --compact          compact instead of pretty-printed output
+      --catalog string   generate catalog to the specified file
+  -v, --verbose          verbose logging
+  -V, --version          print version
+  -h, --help             help for k6registry
 ```
 
 <!-- #endregion cli -->

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     required: false
 
   catalog:
-    description: generate catalog instead of registry
+    description: generate catalog to the specified file
     required: false
 
   origin:

--- a/cmd/k6registry/main.go
+++ b/cmd/k6registry/main.go
@@ -92,8 +92,8 @@ func getArgs() []string {
 		args = append(args, "--compact")
 	}
 
-	if getenv("INPUT_CATALOG", "false") == "true" {
-		args = append(args, "--catalog")
+	if catalog := getenv("INPUT_CATALOG", ""); len(catalog) != 0 {
+		args = append(args, "--catalog", catalog)
 	}
 
 	if api := getenv("INPUT_API", ""); len(api) != 0 {

--- a/docs/custom-catalog.json
+++ b/docs/custom-catalog.json
@@ -71,6 +71,10 @@
     "categories": [
       "data"
     ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
     "constraints": ">=v0.4.0",
     "description": "Generate random fake data",
     "imports": [
@@ -88,7 +92,7 @@
       "name": "xk6-faker",
       "owner": "grafana",
       "public": true,
-      "stars": 54,
+      "stars": 55,
       "timestamp": 1725533453,
       "topics": [
         "xk6"
@@ -132,6 +136,10 @@
     "categories": [
       "data"
     ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
     "description": "Load-test SQL Servers",
     "imports": [
       "k6/x/sql"
@@ -148,7 +156,7 @@
       "name": "xk6-sql",
       "owner": "grafana",
       "public": true,
-      "stars": 109,
+      "stars": 110,
       "timestamp": 1725979901,
       "topics": [
         "k6",

--- a/docs/custom.json
+++ b/docs/custom.json
@@ -58,6 +58,10 @@
     "categories": [
       "data"
     ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
     "constraints": ">=v0.4.0",
     "description": "Generate random fake data",
     "imports": [
@@ -75,7 +79,7 @@
       "name": "xk6-faker",
       "owner": "grafana",
       "public": true,
-      "stars": 54,
+      "stars": 55,
       "timestamp": 1725533453,
       "topics": [
         "xk6"
@@ -91,6 +95,10 @@
     "categories": [
       "data"
     ],
+    "compliance": {
+      "grade": "A",
+      "level": 100
+    },
     "description": "Load-test SQL Servers",
     "imports": [
       "k6/x/sql"
@@ -107,7 +115,7 @@
       "name": "xk6-sql",
       "owner": "grafana",
       "public": true,
-      "stars": 109,
+      "stars": 110,
       "timestamp": 1725979901,
       "topics": [
         "k6",

--- a/releases/v0.1.29.md
+++ b/releases/v0.1.29.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.29` is here 🎉!
+
+This is an internal maintenance release.
+
+**Generate catalog and registry at the same time**
+
+During customization, it is often necessary to generate both catalog and registry. These two outputs can now be generated simultaneously, with a single `k6registry` run.
+
+The `--catalog` flag now specifies the location of the generated catalog.


### PR DESCRIPTION
During customization, it is often necessary to generate both catalog and registry. These two outputs can now be generated simultaneously, with a single `k6registry` run.

The `--catalog` flag now specifies the location of the generated catalog.