### PR TITLE
sort the versions property

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -197,38 +197,6 @@ func loadRepository(ctx context.Context, ext *k6registry.Extension) (*k6registry
 	return nil, nil, fmt.Errorf("%w: %s", errUnsupportedModule, module)
 }
 
-func tagsToVersions(tags []string) []string {
-	versions := make([]string, 0, len(tags))
-
-	for _, tag := range tags {
-		_, err := semver.NewVersion(tag)
-		if err != nil {
-			continue
-		}
-
-		versions = append(versions, tag)
-	}
-
-	return versions
-}
-
-func filterVersions(tags []string, constraints *semver.Constraints) []string {
-	versions := make([]string, 0, len(tags))
-
-	for _, tag := range tags {
-		version, err := semver.NewVersion(tag)
-		if err != nil {
-			continue
-		}
-
-		if constraints.Check(version) {
-			versions = append(versions, tag)
-		}
-	}
-
-	return versions
-}
-
 func loadGitHub(ctx context.Context, module string) (*k6registry.Repository, []string, error) {
 	slog.Debug("Loading GitHub repository", "module", module)
 

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -142,6 +142,10 @@ func load(ctx context.Context, in io.Reader, loose bool, lint bool, origin strin
 
 			ext.Versions = filterVersions(ext.Versions, constraints)
 		}
+
+		if err := sortVersions(ext.Versions); err != nil {
+			return nil, err
+		}
 	}
 
 	if lint {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,35 @@
+package cmd
+
+import "github.com/Masterminds/semver/v3"
+
+func tagsToVersions(tags []string) []string {
+	versions := make([]string, 0, len(tags))
+
+	for _, tag := range tags {
+		_, err := semver.NewVersion(tag)
+		if err != nil {
+			continue
+		}
+
+		versions = append(versions, tag)
+	}
+
+	return versions
+}
+
+func filterVersions(tags []string, constraints *semver.Constraints) []string {
+	versions := make([]string, 0, len(tags))
+
+	for _, tag := range tags {
+		version, err := semver.NewVersion(tag)
+		if err != nil {
+			continue
+		}
+
+		if constraints.Check(version) {
+			versions = append(versions, tag)
+		}
+	}
+
+	return versions
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/Masterminds/semver/v3"
+import (
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+)
 
 func tagsToVersions(tags []string) []string {
 	versions := make([]string, 0, len(tags))
@@ -32,4 +36,30 @@ func filterVersions(tags []string, constraints *semver.Constraints) []string {
 	}
 
 	return versions
+}
+
+func sortVersions(versions []string) error {
+	type version struct {
+		source string
+		parsed *semver.Version
+	}
+
+	all := make([]*version, 0, len(versions))
+
+	for _, source := range versions {
+		parsed, err := semver.NewVersion(source)
+		if err != nil {
+			return err
+		}
+
+		all = append(all, &version{source: source, parsed: parsed})
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].parsed.Compare(all[j].parsed) > 0 })
+
+	for idx := range all {
+		versions[idx] = all[idx].source
+	}
+
+	return nil
 }

--- a/releases/v0.1.31.md
+++ b/releases/v0.1.31.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.31` is here 🎉!
+
+This is an internal maintenance release.
+
+**Sort the versions property**
+
+The tags queried via the repository manager API happen to be in good order, the most recently created tag is at the beginning of the list. However, this does not guarantee that the list is always ordered according to semantic versioning.
+
+After loading and detecting the versions of the extension during registry generation, the versions property now sorted according to semantic versioning.


### PR DESCRIPTION
The tags queried via the repository manager API happen to be in good order, the most recently created tag is at the beginning of the list. However, this does not guarantee that the list is always ordered according to semantic versioning.

After loading and detecting the versions of the extension during registry generation, the versions property now sorted according to semantic versioning.