### PR TITLE
xk6 topic not required for internal extensions

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -73,17 +73,19 @@ func validateWithLinter(registry k6registry.Registry) error {
 }
 
 func hasTopic(ext k6registry.Extension) bool {
-	found := false
-
 	for _, topic := range ext.Repo.Topics {
 		if topic == "xk6" {
-			found = true
-
-			break
+			return true
 		}
 	}
 
-	return found
+	for _, product := range ext.Products {
+		if product == k6registry.ProductOSS { // for oss, topic is required
+			return false
+		}
+	}
+
+	return true // for non oss, topic isn't required
 }
 
 func lintExtension(ext k6registry.Extension) (bool, []string) {

--- a/releases/v0.1.32.md
+++ b/releases/v0.1.32.md
@@ -1,0 +1,9 @@
+k6registry `v0.1.32` is here 🎉!
+
+This is an internal maintenance release.
+
+**xk6 topic not required for internal extensions**
+
+The internal linter previously expected the `xk6` topic to be set on the extensions repository. In the case of internal (albeit public) extensions, it would not be a good idea to use the `xk6` topic, because that would cause them to appear in the GitHub topic search.
+
+The internal linter now does not expect the xk6 topic to be set for extensions that do not have `oss` in their `products` property. That is, in the case of extensions that cannot be used in Grafana k6, the use of the `xk6` topic is not required.


### PR DESCRIPTION
The internal linter previously expected the `xk6` topic to be set on the extensions repository. In the case of internal (albeit public) extensions, it would not be a good idea to use the `xk6` topic, because that would cause them to appear in the GitHub topic search.

The internal linter now does not expect the xk6 topic to be set for extensions that do not have `oss` in their `products` property. That is, in the case of extensions that cannot be used in Grafana k6, the use of the `xk6` topic is not required.