### PR TITLE
Improve compliance badge support

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -65,6 +65,8 @@ func writeAPIGroupGlobal(registry k6registry.Registry, target string) error {
 	return writeJSON(filepath.Join(target, "catalog.json"), k6registry.RegistryToCatalog(registry))
 }
 
+const gradesvg = `<svg xmlns="http://www.w3.org/2000/svg" width="17" height="20"><clipPath id="B"><rect width="17" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#B)"><path fill="%s" d="M0 0h17v20H0z"/><path fill="url(#A)" d="M0 0h17v20H0z"/></g><g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><text x="85" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="70">%s</text><text x="85" y="140" transform="scale(.1)" fill="#fff" textLength="70">%s</text></g></svg>` //nolint:lll
+
 func writeAPIGroupModule(registry k6registry.Registry, target string) error {
 	base := filepath.Join(target, "module")
 
@@ -72,12 +74,21 @@ func writeAPIGroupModule(registry k6registry.Registry, target string) error {
 		dir := filepath.Join(base, ext.Module)
 
 		if ext.Compliance != nil {
-			b, err := badge.RenderBytes("k6 registry", string(ext.Compliance.Grade), badgecolor(ext.Compliance.Grade))
+			sgrade := string(ext.Compliance.Grade)
+
+			b, err := badge.RenderBytes("k6 registry", sgrade, badgecolor(ext.Compliance.Grade))
 			if err != nil {
 				return err
 			}
 
 			err = writeData(filepath.Join(dir, "badge.svg"), b)
+			if err != nil {
+				return err
+			}
+
+			grade := fmt.Sprintf(gradesvg, badgecolor(ext.Compliance.Grade), sgrade, sgrade)
+
+			err = writeData(filepath.Join(dir, "grade.svg"), []byte(grade))
 			if err != nil {
 				return err
 			}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -157,7 +157,9 @@ func checkCompliance(ctx context.Context, module string, cloneURL string, tstamp
 		return nil, err
 	}
 
-	compliance.Checks = nil
+	for idx := range compliance.Checks {
+		compliance.Checks[idx].Details = ""
+	}
 
 	err = saveCompliance(ctx, module, compliance)
 	if err != nil {

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -105,7 +105,19 @@ func loadOne(ctx context.Context, ext *k6registry.Extension, lint bool) error {
 			return err
 		}
 
-		ext.Compliance = &k6registry.Compliance{Grade: k6registry.Grade(compliance.Grade), Level: compliance.Level}
+		var issues []string
+
+		for _, check := range compliance.Checks {
+			if !check.Passed {
+				issues = append(issues, string(check.ID))
+			}
+		}
+
+		ext.Compliance = &k6registry.Compliance{
+			Grade:  k6registry.Grade(compliance.Grade),
+			Level:  compliance.Level,
+			Issues: issues,
+		}
 	}
 
 	return nil

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -186,6 +186,23 @@
             "C",
             "A"
           ]
+        },
+        "issues": {
+          "type": "array",
+          "description": "A list of compliance check IDs that failed.\n\nThe `issues`` property is primarily used for debugging. It contains the (implementation-dependent) identifiers of those compliance checks that failed.\n",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "build",
+              "smoke"
+            ],
+            [
+              "readme",
+              "versions"
+            ]
+          ]
         }
       },
       "additionalProperties": false

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -35,6 +35,13 @@ type Compliance struct {
 	//
 	Grade Grade `json:"grade" yaml:"grade" mapstructure:"grade"`
 
+	// A list of compliance check IDs that failed.
+	//
+	// The `issues`` property is primarily used for debugging. It contains the
+	// (implementation-dependent) identifiers of those compliance checks that failed.
+	//
+	Issues []string `json:"issues,omitempty" yaml:"issues,omitempty" mapstructure:"issues,omitempty"`
+
 	// Compliance expressed as a percentage.
 	//
 	// The `level` property contains a percentage of how well the extension complies

--- a/releases/v0.1.34.md
+++ b/releases/v0.1.34.md
@@ -1,0 +1,6 @@
+k6registry `v0.1.34` is here 🎉!
+
+This is an internal maintenance release.
+- Add go tooling to docker image (k6lint build checker requires it)
+- Keep a list of failed k6lint checkers (for debugging purposes)
+- Generate a grade badge that only contains the grade letter


### PR DESCRIPTION
- keep a list of failed k6lint checkers (for debugging purposes)
- generate a grade badge that only contains the grade letter
