### PR TITLE
Use golang:1.23.3-alpine3.20 base image

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM golang:1.22.9-alpine3.20
+FROM golang:1.23.3-alpine3.20
 
 RUN addgroup -g 127 -S docker && adduser -D -u 1001 -G docker runner && \
     apk update && apk add git


### PR DESCRIPTION
Use golang:1.23.3-alpine3.20 base image in GitHub action image.