### PR TITLE
add metrics to api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ After modifying registry schema ([registry.schema.json]), the [registry_gen.go] 
 
 ```bash
 curl -s -o docs/registry.schema.json https://raw.githubusercontent.com/grafana/k6-extension-registry/main/registry.schema.json
-go-jsonschema --capitalization URL --capitalization OSS -p k6registry --only-models -o registry_gen.go docs/registry.schema.json
+go-jsonschema --capitalization URL --capitalization JavaScript --capitalization OSS -p k6registry --only-models -o registry_gen.go docs/registry.schema.json
 ```
 
 [registry.schema.json]: docs/registry.schema.json

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -352,9 +352,9 @@ func badgecolor(grade k6registry.Grade) badge.Color {
 	case k6registry.GradeC:
 		return "yellowgreen"
 	case k6registry.GradeD:
-		return "orange"
-	case k6registry.GradeE:
 		return "yellow"
+	case k6registry.GradeE:
+		return "orange"
 	case k6registry.GradeF:
 		return "red"
 	default:

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -62,7 +62,11 @@ func writeAPIGroupGlobal(registry k6registry.Registry, target string) error {
 		return err
 	}
 
-	return writeJSON(filepath.Join(target, "catalog.json"), k6registry.RegistryToCatalog(registry))
+	if err := writeJSON(filepath.Join(target, "catalog.json"), k6registry.RegistryToCatalog(registry)); err != nil {
+		return err
+	}
+
+	return writeJSON(filepath.Join(target, "metrics.json"), k6registry.CalculateMetrics(registry))
 }
 
 const gradesvg = `<svg xmlns="http://www.w3.org/2000/svg" width="17" height="20"><clipPath id="B"><rect width="17" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#B)"><path fill="%s" d="M0 0h17v20H0z"/><path fill="url(#A)" d="M0 0h17v20H0z"/></g><g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><text x="85" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="70">%s</text><text x="85" y="140" transform="scale(.1)" fill="#fff" textLength="70">%s</text></g></svg>` //nolint:lll

--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -397,6 +397,197 @@
           "protocol"
         ]
       ]
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Extension registry metrics.",
+      "properties": {
+        "registry_extension_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "The total number of extensions."
+        },
+        "registry_tier_official_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'official' tier."
+        },
+        "registry_tier_unofficial_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of unofficial extensions."
+        },
+        "registry_tier_partner_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'partner' tier."
+        },
+        "registry_tier_community_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extension in the community' tier."
+        },
+        "registry_type_javascript_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of JavaScript extension."
+        },
+        "registry_type_output_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of Output extension."
+        },
+        "registry_product_cloud_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions available in Grafana Cloud k6."
+        },
+        "registry_product_oss_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions available in Grafana k6."
+        },
+        "registry_product_synthetic_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions available in Synthetic Monitoring."
+        },
+        "registry_grade_a_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of A-grade extensions."
+        },
+        "registry_grade_b_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of B-grade extensions."
+        },
+        "registry_grade_c_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of C-grade extensions."
+        },
+        "registry_grade_d_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of D-grade extensions."
+        },
+        "registry_grade_e_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of E-grade extensions."
+        },
+        "registry_grade_f_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of F-grade extensions."
+        },
+        "registry_cgo_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions requiring cgo."
+        },
+        "registry_category_authentication_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'authentication' category."
+        },
+        "registry_category_browser_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'browser' category."
+        },
+        "registry_category_data_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'data' category."
+        },
+        "registry_category_kubernetes_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'kubernetes' category."
+        },
+        "registry_category_messaging_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'messaging' category."
+        },
+        "registry_category_misc_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'misc' category."
+        },
+        "registry_category_observability_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'observability' category."
+        },
+        "registry_category_protocol_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'protocol' category."
+        },
+        "registry_category_reporting_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions in the 'reporting' category."
+        },
+        "registry_issue_module_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without valid go.mod."
+        },
+        "registry_issue_replace_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions with replace directive in go.mod."
+        },
+        "registry_issue_readme_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without readme file."
+        },
+        "registry_issue_examples_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without examples directory."
+        },
+        "registry_issue_license_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without suitable OSS license."
+        },
+        "registry_issue_git_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without  git workdir."
+        },
+        "registry_issue_versions_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without semantic versioning git tags."
+        },
+        "registry_issue_build_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions not buildable with the latest k6 version."
+        },
+        "registry_issue_smoke_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without smoke test script."
+        },
+        "registry_issue_types_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without API declaration file."
+        },
+        "registry_issue_codeowners_count": {
+          "type": "integer",
+          "default": 0,
+          "description": "Number of extensions without CODEOWNERS file."
+        }
+      }
     }
   }
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,158 @@
+package k6registry
+
+import "strings"
+
+// CalculateMetrics calculates registry metrics.
+func CalculateMetrics(reg Registry) *Metrics {
+	const k6Module = "go.k6.io/k6"
+	m := new(Metrics)
+
+	for _, ext := range reg {
+		if ext.Module == k6Module {
+			continue
+		}
+
+		m.RegistryExtensionCount++
+
+		m.tier(ext.Tier)
+
+		if ext.Compliance != nil {
+			m.grade(ext.Compliance.Grade)
+		}
+
+		for _, prod := range ext.Products {
+			m.product(prod)
+		}
+
+		if len(ext.Products) == 0 {
+			m.RegistryProductOSSCount++
+		}
+
+		if len(ext.Imports) > 0 {
+			m.RegistryTypeJavaScriptCount++
+		}
+
+		if len(ext.Outputs) > 0 {
+			m.RegistryTypeOutputCount++
+		}
+
+		if strings.HasPrefix(ext.Module, "github.com/grafana/") && ext.Tier != TierOfficial {
+			m.RegistryTierUnofficialCount++
+		}
+
+		for _, cat := range ext.Categories {
+			m.category(cat)
+		}
+
+		if len(ext.Categories) == 0 {
+			m.RegistryCategoryMiscCount++
+		}
+
+		for _, issue := range ext.Compliance.Issues {
+			m.issue(issue)
+		}
+
+		if ext.Cgo {
+			m.RegistryCgoCount++
+		}
+	}
+
+	return m
+}
+
+func (m *Metrics) tier(tier Tier) {
+	switch tier {
+	case TierOfficial:
+		m.RegistryTierOfficialCount++
+	case TierPartner:
+		m.RegistryTierPartnerCount++
+	case TierCommunity:
+		fallthrough
+	default:
+		m.RegistryTierCommunityCount++
+	}
+}
+
+func (m *Metrics) grade(grade Grade) {
+	switch grade {
+	case GradeA:
+		m.RegistryGradeACount++
+	case GradeB:
+		m.RegistryGradeBCount++
+	case GradeC:
+		m.RegistryGradeCCount++
+	case GradeD:
+		m.RegistryGradeDCount++
+	case GradeE:
+		m.RegistryGradeECount++
+	case GradeF:
+		m.RegistryGradeFCount++
+	default:
+	}
+}
+
+func (m *Metrics) product(product Product) {
+	switch product {
+	case ProductCloud:
+		m.RegistryProductCloudCount++
+	case ProductSynthetic:
+		m.RegistryProductSyntheticCount++
+	case ProductOSS:
+		fallthrough
+	default:
+		m.RegistryProductOSSCount++
+	}
+}
+
+func (m *Metrics) category(category Category) {
+	switch category {
+	case CategoryAuthentication:
+		m.RegistryCategoryAuthenticationCount++
+	case CategoryBrowser:
+		m.RegistryCategoryBrowserCount++
+	case CategoryData:
+		m.RegistryCategoryDataCount++
+	case CategoryKubernetes:
+		m.RegistryCategoryKubernetesCount++
+	case CategoryMessaging:
+		m.RegistryCategoryMessagingCount++
+	case CategoryObservability:
+		m.RegistryCategoryObservabilityCount++
+	case CategoryProtocol:
+		m.RegistryCategoryProtocolCount++
+	case CategoryReporting:
+		m.RegistryCategoryReportingCount++
+	case CategoryMisc:
+		fallthrough
+	default:
+		m.RegistryCategoryMiscCount++
+	}
+}
+
+func (m *Metrics) issue(issue string) {
+	switch issue {
+	case "module":
+		m.RegistryIssueModuleCount++
+	case "replace":
+		m.RegistryIssueReplaceCount++
+	case "readme":
+		m.RegistryIssueReadmeCount++
+	case "examples":
+		m.RegistryIssueExamplesCount++
+	case "license":
+		m.RegistryIssueLicenseCount++
+	case "git":
+		m.RegistryIssueGitCount++
+	case "versions":
+		m.RegistryIssueVersionsCount++
+	case "build":
+		m.RegistryIssueBuildCount++
+	case "smoke":
+		m.RegistryIssueSmokeCount++
+	case "types":
+		m.RegistryIssueTypesCount++
+	case "codeowners":
+		m.RegistryIssueCodeownersCount++
+	default:
+	}
+}

--- a/registry_gen.go
+++ b/registry_gen.go
@@ -199,6 +199,120 @@ const GradeE Grade = "E"
 const GradeF Grade = "F"
 const GradeG Grade = "G"
 
+// Extension registry metrics.
+type Metrics struct {
+	// Number of extensions in the 'authentication' category.
+	RegistryCategoryAuthenticationCount int `json:"registry_category_authentication_count,omitempty" yaml:"registry_category_authentication_count,omitempty" mapstructure:"registry_category_authentication_count,omitempty"`
+
+	// Number of extensions in the 'browser' category.
+	RegistryCategoryBrowserCount int `json:"registry_category_browser_count,omitempty" yaml:"registry_category_browser_count,omitempty" mapstructure:"registry_category_browser_count,omitempty"`
+
+	// Number of extensions in the 'data' category.
+	RegistryCategoryDataCount int `json:"registry_category_data_count,omitempty" yaml:"registry_category_data_count,omitempty" mapstructure:"registry_category_data_count,omitempty"`
+
+	// Number of extensions in the 'kubernetes' category.
+	RegistryCategoryKubernetesCount int `json:"registry_category_kubernetes_count,omitempty" yaml:"registry_category_kubernetes_count,omitempty" mapstructure:"registry_category_kubernetes_count,omitempty"`
+
+	// Number of extensions in the 'messaging' category.
+	RegistryCategoryMessagingCount int `json:"registry_category_messaging_count,omitempty" yaml:"registry_category_messaging_count,omitempty" mapstructure:"registry_category_messaging_count,omitempty"`
+
+	// Number of extensions in the 'misc' category.
+	RegistryCategoryMiscCount int `json:"registry_category_misc_count,omitempty" yaml:"registry_category_misc_count,omitempty" mapstructure:"registry_category_misc_count,omitempty"`
+
+	// Number of extensions in the 'observability' category.
+	RegistryCategoryObservabilityCount int `json:"registry_category_observability_count,omitempty" yaml:"registry_category_observability_count,omitempty" mapstructure:"registry_category_observability_count,omitempty"`
+
+	// Number of extensions in the 'protocol' category.
+	RegistryCategoryProtocolCount int `json:"registry_category_protocol_count,omitempty" yaml:"registry_category_protocol_count,omitempty" mapstructure:"registry_category_protocol_count,omitempty"`
+
+	// Number of extensions in the 'reporting' category.
+	RegistryCategoryReportingCount int `json:"registry_category_reporting_count,omitempty" yaml:"registry_category_reporting_count,omitempty" mapstructure:"registry_category_reporting_count,omitempty"`
+
+	// Number of extensions requiring cgo.
+	RegistryCgoCount int `json:"registry_cgo_count,omitempty" yaml:"registry_cgo_count,omitempty" mapstructure:"registry_cgo_count,omitempty"`
+
+	// The total number of extensions.
+	RegistryExtensionCount int `json:"registry_extension_count,omitempty" yaml:"registry_extension_count,omitempty" mapstructure:"registry_extension_count,omitempty"`
+
+	// Number of A-grade extensions.
+	RegistryGradeACount int `json:"registry_grade_a_count,omitempty" yaml:"registry_grade_a_count,omitempty" mapstructure:"registry_grade_a_count,omitempty"`
+
+	// Number of B-grade extensions.
+	RegistryGradeBCount int `json:"registry_grade_b_count,omitempty" yaml:"registry_grade_b_count,omitempty" mapstructure:"registry_grade_b_count,omitempty"`
+
+	// Number of C-grade extensions.
+	RegistryGradeCCount int `json:"registry_grade_c_count,omitempty" yaml:"registry_grade_c_count,omitempty" mapstructure:"registry_grade_c_count,omitempty"`
+
+	// Number of D-grade extensions.
+	RegistryGradeDCount int `json:"registry_grade_d_count,omitempty" yaml:"registry_grade_d_count,omitempty" mapstructure:"registry_grade_d_count,omitempty"`
+
+	// Number of E-grade extensions.
+	RegistryGradeECount int `json:"registry_grade_e_count,omitempty" yaml:"registry_grade_e_count,omitempty" mapstructure:"registry_grade_e_count,omitempty"`
+
+	// Number of F-grade extensions.
+	RegistryGradeFCount int `json:"registry_grade_f_count,omitempty" yaml:"registry_grade_f_count,omitempty" mapstructure:"registry_grade_f_count,omitempty"`
+
+	// Number of extensions not buildable with the latest k6 version.
+	RegistryIssueBuildCount int `json:"registry_issue_build_count,omitempty" yaml:"registry_issue_build_count,omitempty" mapstructure:"registry_issue_build_count,omitempty"`
+
+	// Number of extensions without CODEOWNERS file.
+	RegistryIssueCodeownersCount int `json:"registry_issue_codeowners_count,omitempty" yaml:"registry_issue_codeowners_count,omitempty" mapstructure:"registry_issue_codeowners_count,omitempty"`
+
+	// Number of extensions without examples directory.
+	RegistryIssueExamplesCount int `json:"registry_issue_examples_count,omitempty" yaml:"registry_issue_examples_count,omitempty" mapstructure:"registry_issue_examples_count,omitempty"`
+
+	// Number of extensions without  git workdir.
+	RegistryIssueGitCount int `json:"registry_issue_git_count,omitempty" yaml:"registry_issue_git_count,omitempty" mapstructure:"registry_issue_git_count,omitempty"`
+
+	// Number of extensions without suitable OSS license.
+	RegistryIssueLicenseCount int `json:"registry_issue_license_count,omitempty" yaml:"registry_issue_license_count,omitempty" mapstructure:"registry_issue_license_count,omitempty"`
+
+	// Number of extensions without valid go.mod.
+	RegistryIssueModuleCount int `json:"registry_issue_module_count,omitempty" yaml:"registry_issue_module_count,omitempty" mapstructure:"registry_issue_module_count,omitempty"`
+
+	// Number of extensions without readme file.
+	RegistryIssueReadmeCount int `json:"registry_issue_readme_count,omitempty" yaml:"registry_issue_readme_count,omitempty" mapstructure:"registry_issue_readme_count,omitempty"`
+
+	// Number of extensions with replace directive in go.mod.
+	RegistryIssueReplaceCount int `json:"registry_issue_replace_count,omitempty" yaml:"registry_issue_replace_count,omitempty" mapstructure:"registry_issue_replace_count,omitempty"`
+
+	// Number of extensions without smoke test script.
+	RegistryIssueSmokeCount int `json:"registry_issue_smoke_count,omitempty" yaml:"registry_issue_smoke_count,omitempty" mapstructure:"registry_issue_smoke_count,omitempty"`
+
+	// Number of extensions without API declaration file.
+	RegistryIssueTypesCount int `json:"registry_issue_types_count,omitempty" yaml:"registry_issue_types_count,omitempty" mapstructure:"registry_issue_types_count,omitempty"`
+
+	// Number of extensions without semantic versioning git tags.
+	RegistryIssueVersionsCount int `json:"registry_issue_versions_count,omitempty" yaml:"registry_issue_versions_count,omitempty" mapstructure:"registry_issue_versions_count,omitempty"`
+
+	// Number of extensions available in Grafana Cloud k6.
+	RegistryProductCloudCount int `json:"registry_product_cloud_count,omitempty" yaml:"registry_product_cloud_count,omitempty" mapstructure:"registry_product_cloud_count,omitempty"`
+
+	// Number of extensions available in Grafana k6.
+	RegistryProductOSSCount int `json:"registry_product_oss_count,omitempty" yaml:"registry_product_oss_count,omitempty" mapstructure:"registry_product_oss_count,omitempty"`
+
+	// Number of extensions available in Synthetic Monitoring.
+	RegistryProductSyntheticCount int `json:"registry_product_synthetic_count,omitempty" yaml:"registry_product_synthetic_count,omitempty" mapstructure:"registry_product_synthetic_count,omitempty"`
+
+	// Number of extension in the community' tier.
+	RegistryTierCommunityCount int `json:"registry_tier_community_count,omitempty" yaml:"registry_tier_community_count,omitempty" mapstructure:"registry_tier_community_count,omitempty"`
+
+	// Number of extensions in the 'official' tier.
+	RegistryTierOfficialCount int `json:"registry_tier_official_count,omitempty" yaml:"registry_tier_official_count,omitempty" mapstructure:"registry_tier_official_count,omitempty"`
+
+	// Number of extensions in the 'partner' tier.
+	RegistryTierPartnerCount int `json:"registry_tier_partner_count,omitempty" yaml:"registry_tier_partner_count,omitempty" mapstructure:"registry_tier_partner_count,omitempty"`
+
+	// Number of unofficial extensions.
+	RegistryTierUnofficialCount int `json:"registry_tier_unofficial_count,omitempty" yaml:"registry_tier_unofficial_count,omitempty" mapstructure:"registry_tier_unofficial_count,omitempty"`
+
+	// Number of JavaScript extension.
+	RegistryTypeJavaScriptCount int `json:"registry_type_javascript_count,omitempty" yaml:"registry_type_javascript_count,omitempty" mapstructure:"registry_type_javascript_count,omitempty"`
+
+	// Number of Output extension.
+	RegistryTypeOutputCount int `json:"registry_type_output_count,omitempty" yaml:"registry_type_output_count,omitempty" mapstructure:"registry_type_output_count,omitempty"`
+}
+
 type Product string
 
 const ProductCloud Product = "cloud"

--- a/releases/v0.1.36.md
+++ b/releases/v0.1.36.md
@@ -1,0 +1,4 @@
+k6registry `v0.1.36` is here 🎉!
+
+This is an internal maintenance release.
+- Based on the properties of the registered extensions, metrics added and available as /metrics.json API endpoint.


### PR DESCRIPTION
Based on the properties of the registered extensions, metrics added and available as /metrics.json API endpoint.