### PR TITLE
fix registry change detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,48 +464,15 @@ If you have a go development environment, the installation can also be done with
 go install github.com/grafana/k6registry/cmd/k6registry@latest
 ```
 
-## GitHub Action
+## GitHub Workflows
 
-`grafana/k6registry` is a GitHub Action that enables k6 Extension Registry and Catalog generation.
-
-**Inputs**
-
-name   | reqired | default | description
--------|---------|---------|-------------
-in     |   yes   |         | input file name
-out    |    no   |  stdout | output file name
-api    |    no   |         | output directory name
-test   |    no   |         | api path(s) to test after generation
-quiet  |    no   | `false` | no output, only validation
-loose  |    no   | `false` | skip JSON schema validation
-lint   |    no   | `false` | enable built-in linter
-compact|    no   | `false` | compact instead of pretty-printed output
-catalog|    no   |         | generate catalog to the specified file
-ref    |    no   |         | reference output URL for change detection
-origin |    no   |         | external registry URL for default values
-
-In GitHub action mode, the change can be indicated by comparing the output to a reference output. The reference output URL can be passed in the `ref` action parameter. The `changed` output variable will be `true` or `false` depending on whether the output has changed or not compared to the reference output.
-
-The `api` parameter can be used to specify a directory into which the outputs are written. The `registry.json` file is placed in the root directory. The `extension.json` file and the `badge.svg` file are placed in a directory with the same name as the go module path of the extension (if the `lint` parameter is `true`).
-
-The `test` parameter can be used to test registry and catalog files generated with the `api` parameter. The test is successful if the file is not empty, contains `k6` and at least one extension, and if all extensions meet the minimum requirements (e.g. it has versions).
+When used in GitHub Workflows, the change can be indicated by comparing the output to a reference output. The reference output URL can be passed in the `--ref` flag. The `changed` output variable will be `true` or `false` depending on whether the output has changed or not compared to the reference output.
 
 **Outputs**
 
 name    | description
 --------|------------
 changed | `true` if the output has changed compared to `ref`, otherwise `false`
-
-**Example usage**
-
-```yaml
-- name: Generate extension registry
-  uses: grafana/k6registry@v0.1.18
-  with:
-    in: "registry.yaml"
-    out: "registry.json"
-    lint: "true"
-```
 
 ## CLI
 
@@ -541,6 +508,7 @@ k6registry [flags] [source-file]
   -o, --out string       write output to file instead of stdout
       --api string       write outputs to directory instead of stdout
       --origin string    external registry URL for default values
+      --ref string       reference output URL for change detection
       --test strings     test api path(s) (example: /registry.json,/catalog.json)
   -q, --quiet            no output, only validation
       --loose            skip JSON schema validation

--- a/releases/v0.2.1.md
+++ b/releases/v0.2.1.md
@@ -1,0 +1,4 @@
+k6registry `v0.2.1` is here 🎉!
+
+This is a bugfix release.
+- There was a bug in the change detection, which made it only work when using the `--out` flag. This has been fixed and now the change detection also works when using the `--api` flag.


### PR DESCRIPTION
There was a bug in the change detection, which made it only work when using the `--out` flag. This has been fixed and now the change detection also works when using the `--api` flag.
