### PR TITLE
registry schema update

### DIFF
--- a/docs/registry.schema.json
+++ b/docs/registry.schema.json
@@ -33,7 +33,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^k6/x/"
+            "pattern": "^k6$|^k6/x/"
           },
           "description": "List of JavaScript import paths registered by the extension.\n\nCurrently, paths must start with the prefix `k6/x/`.\n\nThe extensions used by k6 scripts are automatically detected based on the values specified here, therefore it is important that the values used here are consistent with the values registered by the extension at runtime.\n",
           "examples": [

--- a/releases/v0.2.4.md
+++ b/releases/v0.2.4.md
@@ -5,4 +5,4 @@ This release includes improvements to the generated metrics:
 ## Registry schema update
 
 - k6 can also be added to the registry as a fictitious extension
-- version constraints can also be defined for, not just for extensions
+- version constraints can also be defined for k6, not just for extensions

--- a/releases/v0.2.4.md
+++ b/releases/v0.2.4.md
@@ -1,0 +1,8 @@
+k6registry `v0.2.4` is here 🎉!
+
+This release includes improvements to the generated metrics:
+
+## Registry schema update
+
+- k6 can also be added to the registry as a fictitious extension
+- version constraints can also be defined for, not just for extensions


### PR DESCRIPTION
- k6 can also be added to the registry as a fictitious extension
- version constraints can also be defined for k6, not just for extensions
