### PR TITLE
Release v0.2.6

### DIFF
--- a/releases/v0.2.6.md
+++ b/releases/v0.2.6.md
@@ -1,0 +1,4 @@
+k6registry `v0.2.6` is here 🎉!
+
+This is a maintenance release due to minor dependency updates.
+

--- a/releases/v0.2.6.md
+++ b/releases/v0.2.6.md
@@ -2,3 +2,4 @@ k6registry `v0.2.6` is here 🎉!
 
 This is a maintenance release due to minor dependency updates.
 
+As a side effect, the `golang.org/x/oauth2` dependency has been updated, fixing the CVE-2025-22868 vulnerability.


### PR DESCRIPTION
This is a maintenance release due to minor dependency updates.

As a side effect, the `golang.org/x/oauth2` dependency has been updated, fixing the CVE-2025-22868 vulnerability.