### PR TITLE
Continue on lint errors

### DIFF
--- a/cmd/k6registry/main.go
+++ b/cmd/k6registry/main.go
@@ -30,7 +30,11 @@ func main() {
 	log.SetFlags(0)
 	log.Writer()
 
-	runCmd(newCmd(os.Args[1:], initLogging()))
+	err := newCmd(os.Args[1:], initLogging()).Execute()
+	if err != nil {
+		slog.Error(formatError(err))
+		os.Exit(1)
+	}
 }
 
 func newCmd(args []string, levelVar *slog.LevelVar) *cobra.Command {
@@ -46,7 +50,4 @@ func newCmd(args []string, levelVar *slog.LevelVar) *cobra.Command {
 }
 
 func runCmd(cmd *cobra.Command) {
-	if err := cmd.Execute(); err != nil {
-		log.Fatal(formatError(err))
-	}
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -20,6 +20,9 @@ const (
 	complianceCacheTTL = 60 * 60 * 24 * 7
 
 	xk6Binary = "xk6"
+
+	// xk6 lint returns 2 if some check failed. Other codes mean the lint failed.
+	lintFailedRC = 2
 )
 
 // Check is the result of a particular inspection.
@@ -104,7 +107,6 @@ func checkCompliance(
 	version string,
 	official bool,
 	checks []string,
-	ignoreLintErrors bool,
 	cloneURL string,
 	tstamp int64,
 ) (*Compliance, error) {
@@ -153,9 +155,10 @@ func checkCompliance(
 
 	err = lintCmd.Run()
 	if err != nil {
-		slog.Debug("xk6 execution failed", "rc", lintCmd.ProcessState.ExitCode(), "stderr", lintErr.String())
+		rc := lintCmd.ProcessState.ExitCode()
+		slog.Debug("xk6 execution failed", "rc", rc, "stderr", lintErr.String())
 
-		if !ignoreLintErrors {
+		if rc != lintFailedRC {
 			return nil, fmt.Errorf("xk6 lint failed %w", err)
 		}
 	}


### PR DESCRIPTION
Presetly, the lint process stopped on the first failed compliance found, unless the `--ingonore-lint-errors` flag is set.

After these changes, the process will continue, and all lint errors will be reported, as is the usual practice by linters.

Also, as the details of the lint process are available only by using the `--verbose`, which creates a wall of text, a quick summary of the extension versions that failed the linter will be produced, as shown in the  following example:

```bash 
WARN[0000] compliance check failed github.com/grafana/xk6-dns@v1.0.0
...
compliance check failed github.com/grafana/xk6-sql-driver-sqlserver@v0.1.1
compliance check failed github.com/phymbert/xk6-sse@v0.1.10
compliance check failed github.com/phymbert/xk6-sse@v0.1.11
compliance check failed github.com/grafana/xk6-tls@v0.1.0
ERRO[0000] compliance check failed    # this message is shown only if --ignore-lint-errors is not set
```

