### PR TITLE
feat: recognise go.k6.io/k6/v2 as a valid k6 module path

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -26,6 +27,27 @@ type loadOptions struct {
 	lint             bool
 	ignoreLintErrors bool
 	lintChecks       []string
+}
+
+// isK6Module reports whether module is any major version of the k6 module
+// (go.k6.io/k6, go.k6.io/k6/v2, go.k6.io/k6/v3, ...).
+func isK6Module(module string) bool {
+	if module == k6Module {
+		return true
+	}
+
+	suffix, ok := strings.CutPrefix(module, k6Module+"/")
+	if !ok {
+		return false
+	}
+
+	if !strings.HasPrefix(suffix, "v") {
+		return false
+	}
+
+	n, err := strconv.Atoi(suffix[1:])
+
+	return err == nil && n >= 2
 }
 
 func k6AsExtension() k6registry.Extension {
@@ -58,17 +80,18 @@ func loadSource(in io.Reader) (k6registry.Registry, error) {
 		return nil, err
 	}
 
-	k6 := false
+	hasK6 := false
 
 	for idx := range registry {
-		if registry[idx].Module == k6Module {
-			k6 = true
+		mod := registry[idx].Module
+		if isK6Module(mod) {
+			hasK6 = true
 
 			break
 		}
 	}
 
-	if !k6 {
+	if !hasK6 {
 		registry = append(registry, k6AsExtension())
 	}
 
@@ -228,7 +251,7 @@ func loadRepository(ctx context.Context, ext *k6registry.Extension) (*k6registry
 }
 
 func moduleToOwnerAndName(module string) (string, string) {
-	if module == k6Module {
+	if isK6Module(module) {
 		return "grafana", "k6"
 	}
 

--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func Test_isK6Module(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		module string
+		want   bool
+	}{
+		{"go.k6.io/k6", true},
+		{"go.k6.io/k6/v2", true},
+		{"go.k6.io/k6/v3", true},
+		{"go.k6.io/k6/v10", true},
+		// v0 and v1 have no major version suffix in Go module paths
+		{"go.k6.io/k6/v0", false},
+		{"go.k6.io/k6/v1", false},
+		// not a version suffix
+		{"go.k6.io/k6/extra", false},
+		{"go.k6.io/k6/v", false},
+		{"go.k6.io/k6/v2.1", false},
+		// unrelated modules
+		{"github.com/grafana/xk6-faker", false},
+		{"go.k6.io/k6extra", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.module, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isK6Module(c.module); got != c.want {
+				t.Errorf("isK6Module(%q) = %v, want %v", c.module, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/load_test.go
+++ b/cmd/load_test.go
@@ -1,4 +1,4 @@
-package cmd
+package cmd //nolint:testpackage
 
 import (
 	"testing"


### PR DESCRIPTION
## What

Two small changes to `cmd/load.go` so that a registry source file listing `go.k6.io/k6/v2` (or any future `/vN`) as its k6 entry is handled correctly:

1. **Suppress v1 auto-inject** — when a source file already contains a k6 module, k6registry skips injecting the default `go.k6.io/k6` entry. Previously the check was an exact match on `"go.k6.io/k6"`, so `go.k6.io/k6/v2` was not recognised and a redundant v1 entry was injected. Now the check uses `isK6Module()`.

2. **Repository metadata resolution** — `moduleToOwnerAndName` maps known modules to their GitHub owner/repo. `go.k6.io/k6/v2` (and future major versions) now resolve to `grafana/k6`, the same repo as v1.

## How

A new `isK6Module(module string) bool` helper accepts `go.k6.io/k6` and any `go.k6.io/k6/vN` where N ≥ 2 (standard Go major-version module paths). It rejects `/v0`, `/v1`, non-numeric suffixes, and unrelated modules:

```go
func isK6Module(module string) bool {
    if module == k6Module {
        return true
    }
    suffix, ok := strings.CutPrefix(module, k6Module+"/")
    if !ok {
        return false
    }
    if !strings.HasPrefix(suffix, "v") {
        return false
    }
    n, err := strconv.Atoi(suffix[1:])
    return err == nil && n >= 2
}
```

## Why this approach

v2 compatibility is expressed by which source file an extension appears in (`registry.yaml` vs `registry-v2.yaml`), not by a `k6_versions` field in the registry output. This means no schema changes are needed — k6registry is simply invoked once per source file.

## Testing

11 table-driven unit tests cover the expected true/false cases for `isK6Module`, including edge cases (`/v0`, `/v1`, `/v`, `/v2.1`, unrelated modules).