### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/k6registry
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.