### PR TITLE
fix: suppress gosec G115 with #nosec annotation

### DIFF
--- a/cmd/k6registry/error.go
+++ b/cmd/k6registry/error.go
@@ -13,7 +13,7 @@ type formatableError = interface {
 }
 
 func formatError(err error) string {
-	width, color := formatOptions(int(os.Stderr.Fd())) //nolint:forbidigo,gosec // CLI tool
+	width, color := formatOptions(int(os.Stderr.Fd())) //nolint:forbidigo,gosec // CLI tool #nosec G115
 
 	var perr formatableError
 	if errors.As(err, &perr) {


### PR DESCRIPTION
## Problem

The `v0.5.7` release failed: the Release workflow's **gosec scan (securego/gosec v2.26.1)** flagged **G115** (integer overflow `uintptr -> int`) on the `int(os.Stderr.Fd())` conversion in `formatError`, which skipped the goreleaser job (no binaries published).

The existing `//nolint:forbidigo,gosec` is golangci-lint syntax and is **not** honored by the standalone gosec scanner — gosec requires a `#nosec` annotation **on the reported line**.

## Fix

Add `#nosec G115` to the same line, alongside the existing `//nolint` directive (verified against gosec v2.26.1: 0 issues). The conversion is safe — `os.Stderr.Fd()` returns a small, valid file descriptor.

## Why it slipped past CI

The release failed only at release time, not on the PR. Previously the `validate` workflow ran the **same gosec check** as the release workflow, so passing `validate` guaranteed the release security gate would pass too. **#346 "Move to k6-ci"** replaced `validate` with the `ci` workflow, which does **not** run an equivalent gosec scan — opening a gap where a PR is green but the release fails on security.

**Follow-up (not in this PR):** re-align the two gates — either reuse the release security check in `ci`, or add the same/stronger gosec scan to the `ci` workflow — so CI and release can't diverge again.