### PR TITLE
ci: pin workflow to k6-ci v0.3.0 and set job permissions

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@d63b56ec93af9ebfeedbfb21050865e163cf4a25 # main
+    permissions:
+      contents: read
+    uses: grafana/k6-ci/.github/workflows/all.yml@143ec80c1678ae96a54b82389ea862d4748c27e1 # v0.3.0
     with:
       skip-extension-testing: true


### PR DESCRIPTION
## Summary
- Pin the `checks` job to the tagged `grafana/k6-ci` release v0.3.0 instead of tracking `main` by digest.
- Explicitly declare `permissions: contents: read` on the `checks` job, addressing the zizmor `excessive-permissions` finding from #362.

## Test plan
- [ ] CI passes on this PR